### PR TITLE
Remove deprecated method from iOS sample code

### DIFF
--- a/Document/0x06d-Testing-Data-Storage.md
+++ b/Document/0x06d-Testing-Data-Storage.md
@@ -117,7 +117,6 @@ if userDefaults.bool(forKey: "hasRunBefore") == false {
 
     // Update the flag indicator
     userDefaults.set(true, forKey: "hasRunBefore")
-    userDefaults.synchronize() // Forces the app to update UserDefaults
 }
 ```
 


### PR DESCRIPTION
Remove reference to `NSUserDefaults.synchronize` in iOS sample code, as Apple recommends not using it.

> this method is unnecessary and shouldn't be used

Source: https://developer.apple.com/documentation/foundation/nsuserdefaults/1414005-synchronize

This PR closes #2324.
