### PR TITLE
fix broken links to asset files in Doc folder

### DIFF
--- a/docs/MASTG.md
+++ b/docs/MASTG.md
@@ -1,6 +1,6 @@
 # OWASP MASTG
 
-<a href="../MASTG/Intro/0x01-Foreword"><img align="right" style="border-radius: 3px; margin: 3em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="350px" class="grow" src="../assets/mastg_cover.png" /></a>
+<a href="../MASTG/Intro/0x01-Foreword"><img align="right" style="border-radius: 3px; margin: 3em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="350px" class="grow" src="./assets/mastg_cover.png" /></a>
 
 <a href="https://github.com/OWASP/owasp-mastg/">:material-github: GitHub Repo</a>
 

--- a/docs/MASVS.md
+++ b/docs/MASVS.md
@@ -1,6 +1,6 @@
 # OWASP MASVS
 
-<a href="../MASVS/Intro/0x01-Foreword"><img align="right" style="border-radius: 3px; margin: 3em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="350px" class="grow" src="../assets/masvs_cover.png"></a>
+<a href="../MASVS/Intro/0x01-Foreword"><img align="right" style="border-radius: 3px; margin: 3em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="350px" class="grow" src="./assets/masvs_cover.png"></a>
 
 <a href="https://github.com/OWASP/owasp-masvs/">:material-github: GitHub Repo</a>
 

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -1,6 +1,6 @@
 # &#128172; Connect with Us
 
-<img src="../assets/logo_circle.png" width="150px" style="margin-left: 4em; margin-top: 0em;" align="right">
+<img src="./assets/logo_circle.png" width="150px" style="margin-left: 4em; margin-top: 0em;" align="right">
 
 You can follow and reach out to the OWASP MAS team in many ways.
 
@@ -22,7 +22,7 @@ If you'd like to contribute, take a look at our [Contributions page](contributin
 
 ## Carlos Holguera
 
-<img src="../assets/carlos.jpg" width="150px" style="border-radius: 50%; margin-left: 4em;" align="right">
+<img src="./assets/carlos.jpg" width="150px" style="border-radius: 50%; margin-left: 4em;" align="right">
 
 Carlos is a mobile security research engineer who has gained many years of hands-on experience in the field of security testing for mobile apps and embedded systems such as automotive control units and IoT devices. He is passionate about reverse engineering and dynamic instrumentation of mobile apps and is continuously learning and sharing his knowledge.
 
@@ -36,7 +36,7 @@ Carlos is a mobile security research engineer who has gained many years of hands
 
 ## Sven Schleier
 
-<img src="../assets/sven.jpg" width="150px" style="border-radius: 50%; margin-left: 4em;" align="right">
+<img src="./assets/sven.jpg" width="150px" style="border-radius: 50%; margin-left: 4em;" align="right">
 
 Sven is an experienced web and mobile penetration tester and assessed everything from historic Flash applications to progressive mobile apps. He is also a security engineer that supported many projects end-to-end during the SDLC to "build security in". He was speaking at local and international meetups and conferences and is conducting hands-on workshops about web application and mobile app security.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 _First of all,_ [⭐ Give us a Star in GitHub](https://github.com/OWASP/owasp-mastg)!
 
-<a href="https://github.com/OWASP/owasp-mastg"><img src="../../assets/starring.png" width="300px"/></a>
+<a href="https://github.com/OWASP/owasp-mastg"><img src="./assets/starring.png" width="300px"/></a>
 
 <br>
 

--- a/docs/contributing/2_Getting_Started.md
+++ b/docs/contributing/2_Getting_Started.md
@@ -26,7 +26,7 @@ If you just have an **specific question** you can post it to (you need a [GitHub
 
 Once you get your answer please [mark it as answered](https://docs.github.com/en/discussions/collaborating-with-your-community-using-discussions/participating-in-a-discussion#marking-a-comment-as-an-answer). When you mark a question as an answer, GitHub will highlight the comment and replies to the comment to help visitors quickly find the answer.
 
-<img src="../../assets/comment-marked-as-answer.png" width="500px"/>
+<img src="../assets/comment-marked-as-answer.png" width="500px"/>
 
 ## Contribute Online
 

--- a/docs/contributing/3_PRs_and_Reviews.md
+++ b/docs/contributing/3_PRs_and_Reviews.md
@@ -37,11 +37,11 @@ If you'd like to review an open PR please follow these steps:
 
 You can enter single or multi-line comments (click and drag to select the range of lines):
 
-<img src="../../assets/hover-comment-icon.gif" width="500px"/>
+<img src="../assets/hover-comment-icon.gif" width="500px"/>
 
 **Always prefer making "Suggested Changes"** using the `±` button:
 
-<img src="../../assets/suggestion-block.png" width="500px"/>
+<img src="../assets/suggestion-block.png" width="500px"/>
 
 If the suggestion you'd like to make cannot be expressed using "suggested changes" please enter a clear comment explaining what should be fixed (e.g. some paragraphs don't link properly or some essential information cannot be found and should be added).
 

--- a/docs/donate.md
+++ b/docs/donate.md
@@ -27,5 +27,5 @@ We thank our donators for providing the funds to support us on our project activ
 **The OWASP Foundation is very grateful for the support by the individuals and organizations listed. However please note, the OWASP Foundation is strictly vendor neutral and does not endorse any of its supporters. Donations do not influence the content of the MASVS or MASTG in any way.**
 
 <br><br>
-<img style="border-radius: 15px;" src="../assets/donations/donators.png"/>
+<img style="border-radius: 15px;" src="./assets/donations/donators.png"/>
 <br><br>

--- a/docs/donate/steps.md
+++ b/docs/donate/steps.md
@@ -2,7 +2,7 @@
 
 ## 1. Make your Donation
 
-<img align="right" style="margin: 1.3em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="400px" src="../../assets/donations/owasp_donation_form.png" />
+<img align="right" style="margin: 1.3em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="400px" src="../assets/donations/owasp_donation_form.png" />
 
 Click the button to make your donation directly in the official OWASP website:
 
@@ -16,7 +16,7 @@ Click the button to make your donation directly in the official OWASP website:
 
 ## 2. Register your Donation Package (optional)
 
-<img align="right"  style="margin: 1.3em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="400px" src="../../assets/donations/mastg_donation_form.png" />
+<img align="right"  style="margin: 1.3em; box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;" width="400px" src="../assets/donations/mastg_donation_form.png" />
 
 If your donation is above USD 500 you may opt-in for a [Donation Package](#donation-packages) by registering it. We will then, together with the OWASP Foundation, verify and process it.
 

--- a/docs/news.md
+++ b/docs/news.md
@@ -17,7 +17,7 @@ Today we are rebranding our project to “OWASP Mobile App Security (MAS)”. Th
 - OWASP MAS Crackmes (incl. Hacking playground)
 
 <center>
-<img style="width: 80%; border-radius: 5px" src="../assets/news/mas-rebranding.png"/>
+<img style="width: 80%; border-radius: 5px" src="./assets/news/mas-rebranding.png"/>
 </center>
 
 We see MAS reflecting all the consistency, structure and transparency that we’re bringing with our 2.0 versions.


### PR DESCRIPTION
Thank you for submitting a Pull Request to the OWASP MASTG. Please make sure that:

- [ ] Your contribution is written in the 2nd person (e.g. you)
- [ ] Your contribution is written in an active present form for as much as possible.
- [ ] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
- [ ] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

I was recently reading the Contribution Guide and found that the links to the asset files were broken.
This PR fixes that. 