### PR TITLE
Allow write from docgenerator

### DIFF
--- a/.github/workflows/docgenerator.yml
+++ b/.github/workflows/docgenerator.yml
@@ -14,7 +14,7 @@ on:
       - 'Document/**.md'
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   Generate-MASTG-Documents:

--- a/.github/workflows/docgenerator.yml
+++ b/.github/workflows/docgenerator.yml
@@ -13,9 +13,6 @@ on:
     paths:
       - 'Document/**.md'
 
-permissions:
-  contents: write
-
 jobs:
   Generate-MASTG-Documents:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We need to undo the changes from https://github.com/OWASP/owasp-mastg/pull/2239 to be able to release.

This was the issue:

```
> Run softprops/action-gh-release@v[1](https://github.com/OWASP/owasp-mastg/actions/runs/4913261727/jobs/8773325420#step:6:1)
👩‍🏭 Creating new GitHub release for tag v1.6.0...
⚠️ GitHub release failed with status: 403
undefined
retrying... (2 retries remaining)
👩‍🏭 Creating new GitHub release for tag v1.6.0...
⚠️ GitHub release failed with status: 403
undefined
retrying... (1 retries remaining)
👩‍🏭 Creating new GitHub release for tag v1.6.0...
⚠️ GitHub release failed with status: 403
undefined
retrying... (0 retries remaining)
❌ Too many retries. Aborting...
Error: Too many retries.
```

See solution here: https://github.com/softprops/action-gh-release/issues/236