### PR TITLE
Changed value of status_cells in yaml_to_excel.py

### DIFF
--- a/tools/scripts/yaml_to_excel.py
+++ b/tools/scripts/yaml_to_excel.py
@@ -153,7 +153,7 @@ def create_security_requirements_sheet(wb):
         write_header(ws, category_title, mas_styles.MASVS_COLORS[group_id])
         set_columns_width(ws)
 
-        status_cells = 'H8:L400'
+        status_cells = 'I13:L400'
         ws.conditional_formatting.add(status_cells, mas_styles.rule_fail)
         ws.conditional_formatting.add(status_cells, mas_styles.rule_pass)
         ws.conditional_formatting.add(status_cells, mas_styles.rule_na)

--- a/tools/scripts/yaml_to_excel.py
+++ b/tools/scripts/yaml_to_excel.py
@@ -153,7 +153,7 @@ def create_security_requirements_sheet(wb):
         write_header(ws, category_title, mas_styles.MASVS_COLORS[group_id])
         set_columns_width(ws)
 
-        status_cells = 'I13:L400'
+        status_cells = 'I13:I400'
         ws.conditional_formatting.add(status_cells, mas_styles.rule_fail)
         ws.conditional_formatting.add(status_cells, mas_styles.rule_pass)
         ws.conditional_formatting.add(status_cells, mas_styles.rule_na)

--- a/tools/scripts/yaml_to_excel.py
+++ b/tools/scripts/yaml_to_excel.py
@@ -153,7 +153,7 @@ def create_security_requirements_sheet(wb):
         write_header(ws, category_title, mas_styles.MASVS_COLORS[group_id])
         set_columns_width(ws)
 
-        status_cells = 'I13:I400'
+        status_cells = 'I11:I400'
         ws.conditional_formatting.add(status_cells, mas_styles.rule_fail)
         ws.conditional_formatting.add(status_cells, mas_styles.rule_pass)
         ws.conditional_formatting.add(status_cells, mas_styles.rule_na)


### PR DESCRIPTION
The old value of status value contained `H8` which causes the issue described in #2415. See screenshot below:

<img width="898" alt="Screenshot 2023-05-21 at 13 16 57" src="https://github.com/OWASP/owasp-mastg/assets/22095577/07d20da7-b2e8-4d20-9693-b1a33227b23b">


Remediation:
I changed the value of status_cells from `'H8:L400'` to `'I13:L400'`.

Effectiveness: 
I am not entirely sure the if the commit will help, was not able to generate a .xlsx checklist locally.

References:
The only reference that I have used was an earlier commit 3bfc72ebb60bfd6b09051568481a3343781b68a1, looking at the value of status_cells.

Possible next steps:
A separate rule should be made to fix 'status dropdown bar issue' in the remaining tabs (MASVS-AUTH MASVS-CODE), because status dropdown function is not applicable there on I13.

This PR closes #2415 except maybe for the MASVS-AUTH and MASVS-CODE tab.