### PR TITLE
Changed value of status_cells in yaml_to_excel.py because of wrong display in Excel

### DIFF
--- a/tools/scripts/yaml_to_excel.py
+++ b/tools/scripts/yaml_to_excel.py
@@ -153,7 +153,7 @@ def create_security_requirements_sheet(wb):
         write_header(ws, category_title, mas_styles.MASVS_COLORS[group_id])
         set_columns_width(ws)
 
-        status_cells = 'I11:I400'
+        status_cells = 'I13:I400'
         ws.conditional_formatting.add(status_cells, mas_styles.rule_fail)
         ws.conditional_formatting.add(status_cells, mas_styles.rule_pass)
         ws.conditional_formatting.add(status_cells, mas_styles.rule_na)


### PR DESCRIPTION
Within Excel, currently the color of the status column is showed in the second row above the column itself.

Changed the status_cells value to 'I13:I400'.

Fix has not been verified, please check locally!

This PR is related to this closed issue #2415