### PR TITLE
Update r2frida guide examples to use `:` instead of `\` for command start

### DIFF
--- a/techniques/android/MASTG-TECH-0044.md
+++ b/techniques/android/MASTG-TECH-0044.md
@@ -21,7 +21,7 @@ r2 frida://usb//sg.vantagepoint.helloworldjni
 
 > See all options with `r2 frida://?`.
 
-Once in the r2frida session, all commands start with `\`. For example, in radare2 you'd run `i` to display the binary information, but in r2frida you'd use `\i`.
+Once in the r2frida session, all commands start with `:`. For example, in radare2 you'd run `i` to display the binary information, but in r2frida you'd use `:i`.
 
 ### Memory Maps and Inspection
 

--- a/techniques/android/MASTG-TECH-0045.md
+++ b/techniques/android/MASTG-TECH-0045.md
@@ -5,10 +5,10 @@ platform: android
 
 Runtime reverse engineering can be seen as the on-the-fly version of reverse engineering where you don't have the binary data to your host computer. Instead, you'll analyze it straight from the memory of the app.
 
-We'll keep using the HelloWorld JNI app, open a session with r2frida `r2 frida://usb//sg.vantagepoint.helloworldjni` and you can start by displaying the target binary information by using the `\i` command:
+We'll keep using the HelloWorld JNI app, open a session with r2frida `r2 frida://usb//sg.vantagepoint.helloworldjni` and you can start by displaying the target binary information by using the `:i` command:
 
 ```bash
-[0x00000000]> \i
+[0x00000000]> :i
 arch                arm
 bits                64
 os                  linux
@@ -36,7 +36,7 @@ cacheDir            /data/local/tmp
 jniEnv              0x7d30a43c60
 ```
 
-Search all symbols of a certain module with `\is <lib>`, e.g. `\is libnative-lib.so`.
+Search all symbols of a certain module with `:is <lib>`, e.g. `:is libnative-lib.so`.
 
 ```bash
 [0x00000000]> \is libnative-lib.so
@@ -44,18 +44,18 @@ Search all symbols of a certain module with `\is <lib>`, e.g. `\is libnative-lib
 [0x00000000]>
 ```
 
-Which are empty in this case. Alternatively, you might prefer to look into the imports/exports. For example, list the imports with `\ii <lib>`:
+Which are empty in this case. Alternatively, you might prefer to look into the imports/exports. For example, list the imports with `:ii <lib>`:
 
 ```bash
-[0x00000000]> \ii libnative-lib.so
+[0x00000000]> :ii libnative-lib.so
 0x7dbe1159d0 f __cxa_finalize /system/lib64/libc.so
 0x7dbe115868 f __cxa_atexit /system/lib64/libc.so
 ```
 
-And list the exports with `\iE <lib>`:
+And list the exports with `:iE <lib>`:
 
 ```bash
-[0x00000000]> \iE libnative-lib.so
+[0x00000000]> :iE libnative-lib.so
 0x7d1c49954c f Java_sg_vantagepoint_helloworldjni_MainActivity_stringFromJNI
 ```
 
@@ -71,7 +71,7 @@ sg.vantagepoint.helloworldjni.MainActivity
 List class fields:
 
 ```bash
-[0x00000000]> \ic sg.vantagepoint.helloworldjni.MainActivity~sg.vantagepoint.helloworldjni
+[0x00000000]> :ic sg.vantagepoint.helloworldjni.MainActivity~sg.vantagepoint.helloworldjni
 public native java.lang.String sg.vantagepoint.helloworldjni.MainActivity.stringFromJNI()
 public sg.vantagepoint.helloworldjni.MainActivity()
 ```
@@ -81,7 +81,7 @@ Note that we've filtered by package name as this is the `MainActivity` and it in
 You can also display information about the class loader:
 
 ```bash
-[0x00000000]> \icL
+[0x00000000]> :icL
 dalvik.system.PathClassLoader[
  DexPathList[
   [

--- a/techniques/ios/MASTG-TECH-0096.md
+++ b/techniques/ios/MASTG-TECH-0096.md
@@ -21,10 +21,10 @@ r2 frida://usb//iGoat-Swift
 
 ## Memory Maps and Inspection
 
-You can retrieve the app's memory maps by running `\dm`:
+You can retrieve the app's memory maps by running `:dm`:
 
 ```bash
-[0x00000000]> \dm
+[0x00000000]> :dm
 0x0000000100b7c000 - 0x0000000100de0000 r-x /private/var/containers/Bundle/Application/3ADAF47D-A734-49FA-B274-FBCA66589E67/iGoat-Swift.app/iGoat-Swift
 0x0000000100de0000 - 0x0000000100e68000 rw- /private/var/containers/Bundle/Application/3ADAF47D-A734-49FA-B274-FBCA66589E67/iGoat-Swift.app/iGoat-Swift
 0x0000000100e68000 - 0x0000000100e97000 r-- /private/var/containers/Bundle/Application/3ADAF47D-A734-49FA-B274-FBCA66589E67/iGoat-Swift.app/iGoat-Swift
@@ -37,12 +37,12 @@ You can retrieve the app's memory maps by running `\dm`:
 0x0000000100f60000 - 0x00000001012dc000 r-x /private/var/containers/Bundle/Application/3ADAF47D-A734-49FA-B274-FBCA66589E67/iGoat-Swift.app/Frameworks/Realm.framework/Realm
 ```
 
-While you're searching or exploring the app memory, you can always verify where your current offset is located in the memory map. Instead of noting and searching for the memory address in this list you can simply run `\dm.`. You'll find an example in the following section "In-Memory Search".
+While you're searching or exploring the app memory, you can always verify where your current offset is located in the memory map. Instead of noting and searching for the memory address in this list you can simply run `:dm.`. You'll find an example in the following section "In-Memory Search".
 
-If you're only interested into the modules (binaries and libraries) that the app has loaded, you can use the command `\il` to list them all:
+If you're only interested into the modules (binaries and libraries) that the app has loaded, you can use the command `:il` to list them all:
 
 ```bash
-[0x00000000]> \il
+[0x00000000]> :il
 0x0000000100b7c000 iGoat-Swift
 0x0000000100eb4000 TweakInject.dylib
 0x00000001862c0000 SystemConfiguration
@@ -120,7 +120,7 @@ Now take the first hit, seek to it and check your current location in the memory
 
 ```bash
 [0x00000000]> s 0x100d7d332
-[0x100d7d332]> \dm.
+[0x100d7d332]> :dm.
 0x0000000100b7c000 - 0x0000000100de0000 r-x /private/var/containers/Bundle/Application/3ADAF47D-A734-49FA-B274-FBCA66589E67/iGoat-Swift.app/iGoat-Swift
 ```
 
@@ -134,11 +134,11 @@ hits: 1
 0x1c06619c0 hit3_0 owasp-mstg
 ```
 
-In fact, the string could be found at address `0x1c06619c0`. Seek `s` to there and retrieve the current memory region with `\dm.`.
+In fact, the string could be found at address `0x1c06619c0`. Seek `s` to there and retrieve the current memory region with `:dm.`.
 
 ```bash
 [0x100d7d332]> s 0x1c06619c0
-[0x1c06619c0]> \dm.
+[0x1c06619c0]> :dm.
 0x00000001c0000000 - 0x00000001c8000000 rw-
 ```
 

--- a/techniques/ios/MASTG-TECH-0097.md
+++ b/techniques/ios/MASTG-TECH-0097.md
@@ -5,10 +5,10 @@ platform: ios
 
 Runtime reverse engineering can be seen as the on-the-fly version of reverse engineering where you don't have the binary data to your host computer. Instead, you'll analyze it straight from the memory of the app.
 
-We'll keep using the [iGoat-Swift](0x08b-Reference-Apps.md#igoat-swift) app, open a session with r2frida `r2 frida://usb//iGoat-Swift` and you can start by displaying the target binary information by using the `\i` command:
+We'll keep using the [iGoat-Swift](0x08b-Reference-Apps.md#igoat-swift) app, open a session with r2frida `r2 frida://usb//iGoat-Swift` and you can start by displaying the target binary information by using the `:i` command:
 
 ```bash
-[0x00000000]> \i
+[0x00000000]> :i
 arch                arm
 bits                64
 os                  darwin
@@ -25,7 +25,7 @@ isDebuggerAttached  false
 cwd                 /
 ```
 
-Search all symbols of a certain module with `\is <lib>`, e.g. `\is libboringssl.dylib`.
+Search all symbols of a certain module with `:is <lib>`, e.g. `:is libboringssl.dylib`.
 
 The following does a case-insensitive search (grep) for symbols including "aes" (`~+aes`).
 
@@ -44,10 +44,10 @@ The following does a case-insensitive search (grep) for symbols including "aes" 
 
 Or you might prefer to look into the imports/exports. For example:
 
-- List all imports of the main binary: `\ii iGoat-Swift`.
-- List exports of the libc++.1.dylib library: `\iE /usr/lib/libc++.1.dylib`.
+- List all imports of the main binary: `:ii iGoat-Swift`.
+- List exports of the libc++.1.dylib library: `:iE /usr/lib/libc++.1.dylib`.
 
-> For big binaries it's recommended to pipe the output to the internal less program by appending `~..`, i.e. `\ii iGoat-Swift~..` (if not, for this binary, you'd get almost 5000 lines printed to your terminal).
+> For big binaries it's recommended to pipe the output to the internal less program by appending `~..`, i.e. `:ii iGoat-Swift~..` (if not, for this binary, you'd get almost 5000 lines printed to your terminal).
 
 The next thing you might want to look at are the classes:
 
@@ -96,20 +96,20 @@ Imagine that you are interested into `0x000000018eec5c8c - setStringValue:`. You
 ╰           0x18eec5ca8      f4             hlt
 ```
 
-Finally, instead of doing a full memory search for strings, you may want to retrieve the strings from a certain binary and filter them, as you'd do _offline_ with radare2. For this you have to find the binary, seek to it and then run the `\iz` command.
+Finally, instead of doing a full memory search for strings, you may want to retrieve the strings from a certain binary and filter them, as you'd do _offline_ with radare2. For this you have to find the binary, seek to it and then run the `:iz` command.
 
 > It's recommended to apply a filter with a keyword `~<keyword>`/`~+<keyword>` to minimize the terminal output. If just want to explore all results you can also pipe them to the internal less `\iz~..`.
 
 ```bash
-[0x00000000]> \il~iGoa
+[0x00000000]> :il~iGoa
 0x00000001006b8000 iGoat-Swift
 [0x00000000]> s 0x00000001006b8000
-[0x1006b8000]> \iz
+[0x1006b8000]> :iz
 Reading 2.390625MB ...
 Do you want to print 8568 lines? (y/N) N
-[0x1006b8000]> \iz~+hill
+[0x1006b8000]> :iz~+hill
 Reading 2.390625MB ...
-[0x1006b8000]> \iz~+pass
+[0x1006b8000]> :iz~+pass
 Reading 2.390625MB ...
 0x00000001006b93ed  "passwordTextField"
 0x00000001006bb11a  "11iGoat_Swift20KeychainPasswordItemV0C5ErrorO"

--- a/tests/android/MASVS-STORAGE/MASTG-TEST-0011.md
+++ b/tests/android/MASVS-STORAGE/MASTG-TEST-0011.md
@@ -308,7 +308,7 @@ Usage: /[!bf] [arg]  Search stuff (see 'e??search' for options)
 ### Runtime Memory Analysis
 
 Instead of dumping the memory to your host computer, you can alternatively use [r2frida](../../../Document/0x08a-Testing-Tools.md#r2frida). With it, you can analyze and inspect the app's memory while it's running.
-For example, you may run the previous search commands from r2frida and search the memory for a string, hexadecimal values, etc. When doing so, remember to prepend the search command (and any other r2frida specific commands) with a backslash `\` after starting the session with `r2 frida://usb//<name_of_your_app>`.
+For example, you may run the previous search commands from r2frida and search the memory for a string, hexadecimal values, etc. When doing so, remember to prepend the search command (and any other r2frida specific commands) with a backslash `:` after starting the session with `r2 frida://usb//<name_of_your_app>`.
 
 For more information, options and approaches, please refer to section "[In-Memory Search](../../../Document/0x05c-Reverse-Engineering-and-Tampering.md#in-memory-search "In-Memory Search")" in the chapter "Tampering and Reverse Engineering on Android".
 

--- a/tests/ios/MASVS-STORAGE/MASTG-TEST-0060.md
+++ b/tests/ios/MASVS-STORAGE/MASTG-TEST-0060.md
@@ -66,6 +66,6 @@ Usage: /[!bf] [arg]  Search stuff (see 'e??search' for options)
 
 ### Runtime Memory Analysis
 
-By using [r2frida](../../../Document/0x08a-Testing-Tools.md#r2frida) you can analyze and inspect the app's memory while running and without needing to dump it. For example, you may run the previous search commands from r2frida and search the memory for a string, hexadecimal values, etc. When doing so, remember to prepend the search command (and any other r2frida specific commands) with a backslash `\` after starting the session with `r2 frida://usb//<name_of_your_app>`.
+By using [r2frida](../../../Document/0x08a-Testing-Tools.md#r2frida) you can analyze and inspect the app's memory while running and without needing to dump it. For example, you may run the previous search commands from r2frida and search the memory for a string, hexadecimal values, etc. When doing so, remember to prepend the search command (and any other r2frida specific commands) with a backslash `:` after starting the session with `r2 frida://usb//<name_of_your_app>`.
 
 For more information, options and approaches, please refer to section "[In-Memory Search](../../../Document/0x06c-Reverse-Engineering-and-Tampering.md#in-memory-search "In-Memory Search")" in the chapter "Tampering and Reverse Engineering on iOS".

--- a/tools/generic/MASTG-TOOL-0036.md
+++ b/tools/generic/MASTG-TOOL-0036.md
@@ -23,12 +23,12 @@ For more examples on how to connect to frida-server, [see the usage section in t
 
 > The following examples were executed using an Android app but also apply to iOS apps.
 
-Once in the r2frida session, all commands start with `\` or `=!`. For example, in radare2 you'd run `i` to display the binary information, but in r2frida you'd use `\i`.
+Once in the r2frida session, all commands start with `:` or `=!`. For example, in radare2 you'd run `i` to display the binary information, but in r2frida you'd use `:i`.
 
 > See all options with `r2 frida://?`.
 
 ```bash
-[0x00000000]> \i
+[0x00000000]> :i
 arch                x86
 bits                64
 os                  linux
@@ -74,10 +74,10 @@ policyunsupported md algorithmvar bad valuec0"},{"address":"0x561f072c4275", \
 ...
 ```
 
-To list the loaded libraries use the command `\il` and filter the results using the internal grep from radare2 with the command `~`. For example, the following command will list the loaded libraries matching the keywords `keystore`, `ssl` and `crypto`:
+To list the loaded libraries use the command `:il` and filter the results using the internal grep from radare2 with the command `~`. For example, the following command will list the loaded libraries matching the keywords `keystore`, `ssl` and `crypto`:
 
 ```bash
-[0x00000000]> \il~keystore,ssl,crypto
+[0x00000000]> :il~keystore,ssl,crypto
 0x00007f3357b8e000 libssl.so.1.1
 0x00007f3357716000 libcrypto.so.1.1
 ```
@@ -85,7 +85,7 @@ To list the loaded libraries use the command `\il` and filter the results using 
 Similarly, to list the exports and filter the results by a specific keyword:
 
 ```bash
-[0x00000000]> \iE libssl.so.1.1~CIPHER
+[0x00000000]> :iE libssl.so.1.1~CIPHER
 0x7f3357bb7ef0 f SSL_CIPHER_get_bits
 0x7f3357bb8260 f SSL_CIPHER_find
 0x7f3357bb82c0 f SSL_CIPHER_get_digest_nid
@@ -102,7 +102,7 @@ Similarly, to list the exports and filter the results by a specific keyword:
 To list or set a breakpoint use the command db. This is useful when analyzing/modifying memory:
 
 ```bash
-[0x00000000]> \db
+[0x00000000]> :db
 ```
 
 Finally, remember that you can also run Frida JavaScript code with `\.` plus the name of the script:


### PR DESCRIPTION
This PR closes #2448 
