### PR TITLE
Update external_links.js to fix link behavior on MASVS page

### DIFF
--- a/docs/javascripts/external_links.js
+++ b/docs/javascripts/external_links.js
@@ -1,4 +1,7 @@
-if ((window.location.hostname === 'mas.owasp.org' || window.location.hostname === 'localhost') && window.location.pathname.startsWith('/MASTG')) {
+if (
+  (window.location.hostname === 'mas.owasp.org' || window.location.hostname === 'localhost') &&
+  (window.location.pathname.startsWith('/MASTG') || window.location.pathname.startsWith('/MASVS'))
+) {
   const links = document.links;
 
   for (let i = 0; i < links.length; i++) {

--- a/docs/javascripts/external_links.js
+++ b/docs/javascripts/external_links.js
@@ -1,26 +1,28 @@
-if (
-  (window.location.hostname === 'mas.owasp.org' || window.location.hostname === 'localhost') &&
-  (window.location.pathname.startsWith('/MASTG') || window.location.pathname.startsWith('/MASVS'))
-) {
-  const links = document.links;
+document$.subscribe(function () {
+  if (
+    (window.location.hostname === 'mas.owasp.org' || window.location.hostname === 'localhost') &&
+    (window.location.pathname.startsWith('/MASTG') || window.location.pathname.startsWith('/MASVS'))
+  ) {
+    const links = document.links;
 
-  for (let i = 0; i < links.length; i++) {
-    const link = links[i];
-  
-    // Exclude links to mas.owasp.org
-    if (link.hostname === 'mas.owasp.org') {
-      continue; // Skip this link
-    }
-    
-    if (link.hostname !== window.location.hostname) {
-      link.setAttribute('target', '_blank');
-  
-      // Create an icon element (e.g., a small arrow)
-      const icon = document.createElement('span');
-      icon.textContent = ' ↗'; 
-  
-      // Append the icon to the link
-      link.appendChild(icon);
+    for (let i = 0; i < links.length; i++) {
+      const link = links[i];
+
+      // Exclude links to mas.owasp.org
+      if (link.hostname === 'mas.owasp.org') {
+        continue; // Skip this link
+      }
+
+      if (link.hostname !== window.location.hostname) {
+        link.setAttribute('target', '_blank');
+
+        // Create an icon element (e.g., a small arrow)
+        const icon = document.createElement('span');
+        icon.textContent = ' ↗';
+
+        // Append the icon to the link
+        link.appendChild(icon);
+      }
     }
   }
-}
+})


### PR DESCRIPTION
When you open https://mas.owasp.org/MASTG/ you will notice that external links (like github repo for example) will have small arrow icon and _blank attribute that will open the link in the new tab. But https://mas.owasp.org/MASVS/ page doesn't have the same behavior.

This PR modifies the code to enhance the user experience on the MASVS page (https://mas.owasp.org/MASVS/) by ensuring that external links open in a new tab, similar to the behavior on the MASTG page (https://mas.owasp.org/MASTG/). 

This change involves updating the checking if the path starts with '/MASTG' or '/MASVS' and applying the necessary attributes to external links accordingly. It also add `document$.subscribe()` so the code still executed when page navigate (reference: https://github.com/squidfunk/mkdocs-material/issues/5816)

--------

Thank you for submitting a Pull Request to the OWASP MASTG. Please make sure that:

- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR closes #< insert number here >.
