### PR TITLE
Remove "Translating the MASVS" from the docs

### DIFF
--- a/docs/contributing/1_How_Can_You_Contribute.md
+++ b/docs/contributing/1_How_Can_You_Contribute.md
@@ -63,14 +63,3 @@ Refer to Google Technical Writing trainings for more info:
 
 - [Google Technical Writing One](https://developers.google.com/tech-writing/one)
 - [Google Technical Writing Two](https://developers.google.com/tech-writing/two)
-
-## 🌐 Translating the MASVS
-
-Translating the MASVS in a new language is another great way to contribute. This helps the project to reach to more people around the world.
-
-Before starting a translation please consider the following:
-
-- **First of all** contact us on Slack or via email.
-- We need your commitment. After the first translation is done, we will ask for your help to translate any new changes, so your translation can remain up to date.
-- We need a second translator who can verify that the English version of the MASVS has been translated properly.
-- Once you are all set, go to your fork and follow [these steps](4_Add_new_Language.md).


### PR DESCRIPTION
We have had over a dozen translations of the MASVS and a few of the MASTG in the past, but we decided a few years ago to stop because the overhead is too much, as we have to contact dozens of people for each change, and the MASTG just changes too often and it will be impossible to keep it in sync through volunteer work. Also, the amount of content for the MASTG is too much to be translated by volunteers.

See the official statement here: https://mas.owasp.org/MASVS/

Starting with MASVS v2.0.0, translations will no longer be included to focus on the development of MASTG v2.0.0. We encourage the community to create and maintain their own translations. Thank you to all the past translators who generously volunteered their time and expertise to make the MASVS accessible to non-English speaking communities. We truly appreciate your contributions and hope to continue working together in the future. The past MASVS v1.5.0 translations are still available in the MASVS repo.