### PR TITLE
[PREVIEW DRAFT] Adding Risk: data-unencrypted-internal

### DIFF
--- a/risks/MASVS-STORAGE/1-store-sensitive-data-securely/data-unencrypted-internal/android-data-in-sandbox/test.md
+++ b/risks/MASVS-STORAGE/1-store-sensitive-data-securely/data-unencrypted-internal/android-data-in-sandbox/test.md
@@ -1,0 +1,34 @@
+---
+platform: android
+title: Sensitive Data Written to Private Data Directory (Sandbox) Unencrypted.
+type: [dynamic, filesystem]
+mitigations:
+- android-use-keystore
+- android-use-androidx-security
+prerequisites:
+- identify-sensitive-data
+---
+
+## Prerequisites
+
+- [Identify your sensitive data](MASTG-KNOW-0001)
+
+## Steps
+
+1. Start the device.
+
+2. Launch and use the app going through the various workflows while inputting sensitive data wherever you can. Taking note of the data you input can help identify it later using tools to search for it.
+
+3. Take a copy of the app's private data directory for offline analysis. Using tar will preserve the filesystem structure and permissions.
+
+4. Search the extracted data for items such as keys, passwords and any sensitive data inputted into the app.
+
+5. Check files for sensitive data that has been encoded with algorithms such as base64 which obscures but does not protect sensitive data.
+
+## Observation
+
+Files within the private data directory contain sensitive data.
+
+## Evaluation
+
+The test case fails if you find sensitive data in the app's private data directory which has not been encrypted with strong cryptography. This includes plaintext data as well as encoding such as base64 or obfuscation such as xoring.

--- a/risks/MASVS-STORAGE/1-store-sensitive-data-securely/data-unencrypted-internal/risk.md
+++ b/risks/MASVS-STORAGE/1-store-sensitive-data-securely/data-unencrypted-internal/risk.md
@@ -24,7 +24,7 @@ Sensitive data stored locally on the device should be encrypted, and any keys us
 
 ## Modes of Introduction
 
-- **Data Stored Unencrypted**: Sensitive data is written to the file system unencrypted.
+- **Data Stored Unencrypted**: Sensitive data is written to the app's private data directory (sandbox) unencrypted.
 - **Hardcoded Encryption Key**: Sensitive data is encrypted but the key is hardcoded inside the application.
 - **Encryption Key Stored on Filesystem**: Sensitive data is encrypted but the key is stored alongside it or in another easily accessible location.
 - **Encryption Used is Insufficient**: Sensitive data is encrypted but the encryption is not considered to be strong.

--- a/risks/MASVS-STORAGE/1-store-sensitive-data-securely/data-unencrypted-internal/risk.md
+++ b/risks/MASVS-STORAGE/1-store-sensitive-data-securely/data-unencrypted-internal/risk.md
@@ -12,8 +12,25 @@ mappings:
 
 ## Overview
 
+Mobile apps may need to store sensitive data locally within the application sandbox and this data is at risk of exposure via, for example, incorrect file permissions, an app vulnerability, device vulnerability or data backup mechanisms.
+
+[sensitive data](MASTG-THEORY-0023.md "Sensitive Data") may include personally identifiable information (PII), passwords, cryptographic keys or session tokens.
+
+Sensitive data stored locally on the device should be encrypted, and any keys used for encryption methods should be protected by the device's hardware-backed keystore, where available.
+
 ## Impact
+
+- **Loss of Confidentiality**: Under the right conditions an attacker could extract sensitive data stored internally within the application sandbox leading to loss of confidentiality and enable further attacks such as identity theft or account takeover.
 
 ## Modes of Introduction
 
+- **Data Stored Unencrypted**: Sensitive data is written to the file system unencrypted.
+- **Hardcoded Encryption Key**: Sensitive data is encrypted but the key is hardcoded inside the application.
+- **Encryption Key Stored on Filesystem**: Sensitive data is encrypted but the key is stored alongside it or in another easily accessible location.
+- **Encryption Used is Insufficient**: Sensitive data is encrypted but the encryption is not considered to be strong.
+
 ## Mitigations
+
+- Avoid storing sensitive data locally at all.
+- Use the platform's hardware-backed keystore solution to store the key used for encryption.
+- Use platform features such as [androidx.security.crypto](https://developer.android.com/jetpack/androidx/releases/security) to safely store files and sharedpreferences.

--- a/risks/MASVS-STORAGE/1-store-sensitive-data-securely/data-unencrypted-internal/risk.md
+++ b/risks/MASVS-STORAGE/1-store-sensitive-data-securely/data-unencrypted-internal/risk.md
@@ -1,0 +1,19 @@
+---
+title: Sensitive Data Stored Unencrypted in Internal Locations
+alias: data-unencrypted-internal
+platform: [android, ios]
+profiles: [L2]
+mappings:
+  masvs-v1: [MSTG-STORAGE-2]
+  masvs-v2: [MASVS-STORAGE-1, MASVS-CRYPTO-2]
+  mastg-v1: [MASTG-TEST-0052, MASTG-TEST-0001]
+
+---
+
+## Overview
+
+## Impact
+
+## Modes of Introduction
+
+## Mitigations


### PR DESCRIPTION
Initial version for feedback following the new process for defining risks.

I've tried to keep the definitions concise and accurate and used language such as must, should and could when describing expected controls and impacts since addressing this risk depends on the application's threat model as to whether it is necessary.

Closes #2544 