### PR TITLE
Proofreading fix on MASTG-TEST-0072.md -> Testing App Extensions ( by @appknox )

### DIFF
--- a/tests/ios/MASVS-PLATFORM/MASTG-TEST-0072.md
+++ b/tests/ios/MASVS-PLATFORM/MASTG-TEST-0072.md
@@ -51,3 +51,4 @@ ph.telegra.Telegraph on (iPhone: 11.1.2) [usb] # cd PlugIns
 
 ph.telegra.Telegraph on (iPhone: 11.1.2) [usb] # ls
 NSFileType      Perms  NSFileProtection    Read    Write     Name
+```


### PR DESCRIPTION
The 2nd code block under "Verifying if the App Contains App Extensions" is not closed properly. 
As a result, the entire section of  "Testing iOS Webviews" topic is included inside a code block on page no. 455 of MASTG pdf release v1.7.0