### PR TITLE
Proofreading fix on MASTG-TEST-0087.md -> Make Sure That Free Security Features Are Activated( by @appknox )

### DIFF
--- a/tests/ios/MASVS-CODE/MASTG-TEST-0087.md
+++ b/tests/ios/MASVS-CODE/MASTG-TEST-0087.md
@@ -66,4 +66,9 @@ These checks can be performed dynamically using [objection](../../../Document/0x
 ```bash
 com.yourcompany.PPClient on (iPhone: 13.2.3) [usb] # ios info binary
 Name                  Type     Encrypted    PIE    ARC    Canary    Stack Exec    RootSafe
+--------------------  -------  -----------  -----  -----  --------  ------------  ----------
+PayPal                execute  True         True   True   True      False         False
+CardinalMobile        dylib    False        False  True   True      False         False
+FraudForce            dylib    False        False  True   True      False         False
+...
 ```

--- a/tests/ios/MASVS-CODE/MASTG-TEST-0087.md
+++ b/tests/ios/MASVS-CODE/MASTG-TEST-0087.md
@@ -66,3 +66,4 @@ These checks can be performed dynamically using [objection](../../../Document/0x
 ```bash
 com.yourcompany.PPClient on (iPhone: 13.2.3) [usb] # ios info binary
 Name                  Type     Encrypted    PIE    ARC    Canary    Stack Exec    RootSafe
+```


### PR DESCRIPTION
The code block under "Dynamic Analysis"  is not closed properly. 
As a result, the entire section of  "iOS Anti-Reversing Defenses" topic is included inside a code block on page no. 506 of MASTG pdf release v1.7.0 