### PR TITLE
Updated L1 vs L2 recommentation for MASVS-STORAGE

### DIFF
--- a/tests/android/MASVS-STORAGE/MASTG-TEST-0001.md
+++ b/tests/android/MASVS-STORAGE/MASTG-TEST-0001.md
@@ -18,9 +18,9 @@ This test case focuses on identifying potentially sensitive data stored by an ap
 - Analyze data storage in the source code.
 - Be sure to trigger all possible functionality in the application (e.g. by clicking everywhere possible) in order to ensure data generation.
 - Check all application generated and modified files and ensure that the storage method is sufficiently secure.
-    - This includes SharedPreferences, SQL databases, Realm Databases, Internal Storage, External Storage, etc.
-  
-In general sensitive data stored locally on the device should always be at least encrypted, and any keys used for encryption methods should be securely stored within the Android Keystore. These files should also be stored within the application sandbox. If achievable for the application, sensitive data should be stored off device or, even better, not stored at all.
+    - This includes `SharedPreferences`, databases, Internal Storage, External Storage, etc.
+
+**NOTE:** For MASVS L1 compliance, it is sufficient to store data unencrypted in the application's internal storage directory (sandbox). For L2 compliance, additional encryption is required using cryptographic keys securely managed in the Android KeyStore. This includes using envelope encryption (DEK+KEK) or equivalent methods, or using the Android Security Library's [`EncryptedFile`](https://developer.android.com/reference/androidx/security/crypto/EncryptedFile)/[`EncryptedSharedPreferences`](https://developer.android.com/reference/androidx/security/crypto/EncryptedSharedPreferences).
 
 ## Static Analysis
 

--- a/tests/ios/MASVS-STORAGE/MASTG-TEST-0052.md
+++ b/tests/ios/MASVS-STORAGE/MASTG-TEST-0052.md
@@ -13,6 +13,15 @@ masvs_v1_levels:
 
 ## Overview
 
+This test case focuses on identifying potentially sensitive data stored by an application and verifying if it is securely stored. The following checks should be performed:
+
+- Analyze data storage in the source code.
+- Be sure to trigger all possible functionality in the application (e.g. by clicking everywhere possible) in order to ensure data generation.
+- Check all application generated and modified files and ensure that the storage method is sufficiently secure.
+    - This includes `NSUserDefaults`, databases, KeyChain, Internal Storage, External Storage, etc.
+
+**NOTE:** For MASVS L1 compliance, it is sufficient to store data unencrypted in the application's internal storage directory (sandbox). For L2 compliance, additional encryption is required using cryptographic keys securely managed in the iOS KeyChain. This includes using envelope encryption (DEK+KEK) or equivalent methods.
+
 ## Static Analysis
 
 When you have access to the source code of an iOS app, identify sensitive data that's saved and processed throughout the app. This includes passwords, secret keys, and personally identifiable information (PII), but it may as well include other data identified as sensitive by industry regulations, laws, and company policies. Look for this data being saved via any of the local storage APIs listed below.


### PR DESCRIPTION
The MASTG in its version 1.7.0 and earlier recommended to encrypt all sensitive data in the internal memory of an app, even for L1 apps. However, the internal memory on Android and iOS is considered safe enough. Therefore, we are updating the recommendation to reflect this and allow L1 apps to store unencrypted data in internal storage. L2 apps must also encrypt data on internal storage. The recommendation for external storage does not change.