### PR TITLE
Update pandoc_makedocs.sh for pandocker 23.03

### DIFF
--- a/src/pandocker/pandoc_makedocs.sh
+++ b/src/pandocker/pandoc_makedocs.sh
@@ -12,7 +12,7 @@ cp -R $FOLDER "build"
 
 # You can also use the environment variables below to adapt the build process
 IMG=${IMG:-dalibo/pandocker}
-TAG=${TAG:-stable} # /!\ use stable-full for non-european languages
+TAG=${TAG:-23.03} # /!\ use stable-full for non-european languages
 LATEX_TEMPLATE=${LATEX_TEMPLATE:-eisvogel}
 TITLE=${TITLE:-OWASP Mobile Application Security Testing Guide ${MASTG_VERSION}}
 


### PR DESCRIPTION
The new release https://github.com/dalibo/pandocker/releases/tag/24.05 is breaking our doc generation. So we're going back to the previous release 23.03.

```
Digest: sha256:3a0436dfa85c5b12580afc921ebd65097dce3cacf2befdcccac5898e472565ce
Status: Downloaded newer image for dalibo/pandocker:stable
Warning:  Could not fetch resource Images/Chapters/0x03/owasp-mobile-overview.png%22%20alt=%22image: replacing image with description
Error producing PDF.
! Missing \endcsname inserted.
<to be read again> 
                   \__kernel_tl_set:Nx 
l.456 ...aperwidth,height=\paperheight]{cover.pdf}

Error: Process completed with exit code 43.
```