### PR TITLE
Universal edit button

### DIFF
--- a/docs/hooks/edit_button_uri.py
+++ b/docs/hooks/edit_button_uri.py
@@ -1,0 +1,24 @@
+import logging
+import re
+from glob import glob
+log = logging.getLogger('mkdocs')
+
+
+def on_pre_page(page, config, files):
+    try:
+        editor_url = config["editor_url"]
+    except KeyError:
+        return page
+
+    src_path = page.file.src_path
+    
+    edit_url = f"{editor_url}{src_path}"
+    edit_url = edit_url.replace("master/MASTG/", "master/")
+    edit_url = edit_url.replace("master/General/", "master/Document/")
+    edit_url = edit_url.replace("master/Intro/", "master/Document/")
+    edit_url = edit_url.replace("master/iOS/", "master/Document/")
+    edit_url = edit_url.replace("master/Android/", "master/Document/")
+   
+    page.edit_url = edit_url
+ 
+    return page

--- a/docs/hooks/resolve_references.py
+++ b/docs/hooks/resolve_references.py
@@ -1,0 +1,60 @@
+import logging
+import re
+import mkdocs.plugins
+import os
+from glob import glob
+import yaml
+log = logging.getLogger('mkdocs')
+
+mapping = {"TECH":{}, "TOOL":{} }
+
+@mkdocs.plugins.event_priority(-50)
+def on_page_markdown(markdown, page, **kwargs):
+    path = page.file.src_uri
+
+    if path.endswith('file-diff/test.md'):
+
+        pageRefs = {"TECH":[], "TOOL":[] }
+        def replaceReference(match):
+            refType = match.group(2)
+
+            pageRefs[refType].append(match.group(1))
+
+            if not match in mapping[refType]:
+                target = getTargetForRef(match.group(1))
+                mapping[refType][match] = target
+
+            icon = ""
+            if refType == "TOOL":
+                icon = ":material-cog:Tool: "
+            else:
+                icon = ":material-flask:Technique: "
+
+            return f"_[{icon}{mapping[refType][match]['title']}]({mapping[refType][match]['file']})_"
+
+        updated_markdown = re.sub(r'#(MASTG-(TECH|TOOL)-\d{3,})', replaceReference, markdown)
+        tags = page.meta.get('tags', [])
+        page.meta["tools"] = list(set(pageRefs["TOOL"]))
+        page.meta["techniques"] = list(set(pageRefs["TECH"]))
+
+
+        return updated_markdown
+
+
+    return markdown
+
+def getTargetForRef(id):
+    searchFor = os.getcwd() + f'/docs/MASTG/**/{id}.md'
+
+    files = glob(searchFor, recursive=True)
+
+    if not len(files):
+        log.error("Unknown reference: " + id)
+        return {"file": "ERROR", "title": "error"}
+    
+
+    with open(files[0], 'r') as f:
+        content = f.read()
+        metadata = next(yaml.safe_load_all(content))
+
+        return {"file":files[0], "title":metadata['title']}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: OWASP Mobile Application Security
 repo_url: https://github.com/OWASP/owasp-mastg
 repo_name: OWASP/owasp-mastg
 # use_directory_urls: false # only set for mkdocs build
-edit_uri: "" # disable edit button
+editor_url: "https://github.com/OWASP/owasp-mastg/edit/master/"
 
 nav:
   - Home: index.md
@@ -160,6 +160,7 @@ theme:
     - navigation.tracking
     - navigation.indexes
     - content.code.copy
+    - content.action.edit
 
   palette:
     # - primary: #499FFF 
@@ -222,6 +223,7 @@ hooks:
   - docs/hooks/update_titles.py
   - docs/hooks/maswe-beta-banner.py
   - docs/hooks/add-tags.py
+  - docs/hooks/edit_button_uri.py
 
 extra:
   generator: false # removed but recreated in copyright above

--- a/weaknesses/MASVS-STORAGE/1-secure-data-storage/data-unencrypted-shared-storage-no-user-interaction/android-data-unencrypted-shared-storage-no-user-interaction-dynamic-file-diff/test.md
+++ b/weaknesses/MASVS-STORAGE/1-secure-data-storage/data-unencrypted-shared-storage-no-user-interaction/android-data-unencrypted-shared-storage-no-user-interaction-dynamic-file-diff/test.md
@@ -10,9 +10,9 @@ The goal of this test is to retrieve the files written to the external storage a
 
 ## Steps
 
-1. Make sure you have [adb](/MASTG/tools/android/MASTG-TOOL-0004) installed.
-2. [Install the app](/MASTG/techniques/android/MASTG-TECH-0005).
-3. Before running the app, [get the current list of files](/MASTG/techniques/android/MASTG-TECH-0002) in the external storage.
+1. Make sure you have adb (#MASTG-TOOL-0004) installed.
+2. Install the app (#MASTG-TECH-0005).
+3. Before running the app, get the current list of files (#MASTG-TECH-0002) in the external storage.
 4. Exercise the app.
 5. After running the app, retrieve the list of files in the external storage again.
 6. Calculate the difference between the two lists.


### PR DESCRIPTION
This adds a direct edit button on each page.

An mkdocs hook is used to rewrite the URLs which is the result of the complex build pipeline. The hook is pretty lightweight though.

<img width="794" alt="image" src="https://github.com/OWASP/owasp-mastg/assets/1650034/6283411d-7879-4746-ba15-29a7da213474">

This links to: https://github.com/OWASP/owasp-mastg/edit/master/techniques/android/MASTG-TECH-0005.md