### PR TITLE
Fix local build pipeline

### DIFF
--- a/run_web.sh
+++ b/run_web.sh
@@ -1,5 +1,8 @@
 # rm -rf docs/MASTG
-rm -rf docs/MASWE
+# rm -rf docs/MASWE
+# rm -rf docs/MASVS
+
+./src/scripts/structure_masvs.sh
 ./src/scripts/structure_mastg.sh
 python3 src/scripts/transform_files.py
 python3 src/scripts/populate_dynamic_pages.py

--- a/src/scripts/populate_dynamic_pages.py
+++ b/src/scripts/populate_dynamic_pages.py
@@ -100,7 +100,6 @@ def reorder_dict_keys(original_dict, key_order):
 # tests/index.md
 
 column_titles = {'id': 'ID', 'title': 'Name', 'masvs_v2_id': "MASVS v2 ID", 'masvs_v1_id': "MASVS v1 IDs", 'last_updated': 'Last Updated'} #'id': 'ID',  ... , 'refs': 'Refs', 'techniques': 'Techniques'
-
 tests = get_mastg_components_dict("docs/MASTG/tests")
 test_types = ["android", "ios"]
 for test_type in test_types:

--- a/src/scripts/structure_mastg.sh
+++ b/src/scripts/structure_mastg.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-mkdir -p docs/MASTG
 mkdir -p docs/MASTG/Intro      
 mkdir -p docs/MASTG/General
 mkdir -p docs/MASTG/Android

--- a/src/scripts/structure_masvs.sh
+++ b/src/scripts/structure_masvs.sh
@@ -1,11 +1,23 @@
-mkdir docs/MASVS
-mkdir docs/MASVS/Intro
-mkdir docs/MASVS/controls
-cp owasp-masvs/Document/*.md docs/MASVS
-mv docs/MASVS/0[1-4]*.md docs/MASVS/Intro
-mv owasp-masvs/controls/* docs/MASVS/controls
 
-mkdir docs/assets/Images/MASVS
-mv owasp-masvs/Document/images/* docs/assets/Images/MASVS
-sed -i "s#images/#../../../assets/Images/MASVS/#g" docs/MASVS/**/*.md
-sed -i "s#images/#../../assets/Images/MASVS/#g" docs/MASVS/*.md
+if [ ! -d "../owasp-masvs/" ] ; then
+  echo "Error: Clone owasp-masvs to same directory as owasp-mastg"
+  exit
+fi
+
+mkdir -p docs/MASVS/Intro
+mkdir -p docs/MASVS/controls
+cp ../owasp-masvs/Document/*.md docs/MASVS
+mv docs/MASVS/0[1-4]*.md docs/MASVS/Intro
+cp ../owasp-masvs/controls/* docs/MASVS/controls
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    SED="gsed"
+else
+    SED="sed"
+fi
+
+
+mkdir -p docs/assets/Images/MASVS
+cp ../owasp-masvs/Document/images/* docs/assets/Images/MASVS
+$SED -i "s#images/#../../../assets/Images/MASVS/#g" docs/MASVS/**/*.md
+$SED -i "s#images/#../../assets/Images/MASVS/#g" docs/MASVS/*.md


### PR DESCRIPTION
* adds -p flags to avoid errors
* Duplicate gsed check to structure_masvs.sh
* Change `mv` to `cp` to leave owasp-masvs intact

This should be tested on the GitHub build workflow before merging.