### PR TITLE
Remove 'About Hybrid Apps' from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,3 @@ MAS Advocates are industry adopters of the OWASP MASVS and MASTG who have invest
 - Get the [printed version via lulu.com](https://www.lulu.com/shop/jeroen-willemsen-and-sven-schleier-and-bernhard-müller-and-carlos-holguera/owasp-mobile-security-testing-guide/paperback/product-1kw4dp4k.html)
 - Get the [e-book on leanpub.com](https://leanpub.com/owasp-mastg) (please consider purchasing it to support our project or [make a donation](https://mas.owasp.org/donate/#make-your-donation))
 - Check our [Document generation scripts](src/pandocker/README.md)
-
-<br>
-
-## About Hybrid Apps
-
-Please note that the MASTG focuses primarily on native apps. These are apps built with Java or Kotlin using the Android SDK for Android or built with Swift or Objective-C using the Apple SDKs for iOS. Apps using frameworks such as Nativescript, React-native, Xamarin, Cordova, etc. are not within the main focus of the MASTG. However, some essential controls, such as certificate pinning, have been explained already for some of these platforms. For now, you can take a look and contribute to the work-in-progress being made in the discussions ["Hybrid application checklist experiments"](https://github.com/OWASP/owasp-mastg/discussions/1971) and ["Basic Guidelines for Hybrid Apps"](https://github.com/OWASP/owasp-masvs/discussions/557).


### PR DESCRIPTION
Closes #2783

Remove the "About Hybrid Apps" section from the `README.md` file as this disclaimer it's available within the MASTG.