### PR TITLE
Fix MASWE note display issue

### DIFF
--- a/docs/hooks/maswe-beta-banner.py
+++ b/docs/hooks/maswe-beta-banner.py
@@ -75,7 +75,7 @@ def get_info_banner(meta):
     description = draft_info.get('description', None)
 
     if draft_info.get('note', None):
-        description += "\n\n" + "> Note: " + draft_info.get('note', None)
+        description += "\n\n" + "> Note: " + draft_info.get('note', None) + "\n"
 
     topics = draft_info.get('topics', None)
     topics_section = ""


### PR DESCRIPTION
Closes #2795

Add a newline character at the end of the 'note' addition in `docs/hooks/maswe-beta-banner.py`.