### PR TITLE
Add Android demo APKs GitHub action

### DIFF
--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -1,4 +1,5 @@
 name: Build Android Demos
+
 on:
   push:
     branches:
@@ -29,14 +30,19 @@ jobs:
         run: |
           for demo in demos/android/MASTG-DEMO-*; do
             if [ -d "$demo" ]; then
+              echo "Processing $demo"
               cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt || true
               cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml || true
               cd MASTestApp-Android
               ./gradlew assembleDebug
               cd ..
-              mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk"
+              mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk" || echo "Failed to move APK for $demo"
+              echo "APK for $demo moved to $demo.apk"
             fi
           done
+
+      - name: List generated APKs
+        run: ls -l demos/android/*.apk
 
       - name: Upload APKs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -15,10 +15,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up JDK 11
+      - name: set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
 
       - name: Clone MASTestApp-Android repository
         run: git clone https://github.com/cpholguera/MASTestApp-Android.git

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -35,14 +35,22 @@ jobs:
               cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml || true
               cd MASTestApp-Android
               ./gradlew assembleDebug
+              build_status=$?
               cd ..
-              mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk" || echo "Failed to move APK for $demo"
-              echo "APK for $demo moved to $demo.apk"
+              if [ $build_status -eq 0 ]; then
+                echo "Build succeeded for $demo"
+                mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk" || echo "Failed to move APK for $demo"
+                echo "APK for $demo moved to $demo.apk"
+              else
+                echo "Build failed for $demo"
+              fi
             fi
           done
 
       - name: List generated APKs
-        run: ls -l demos/android/*.apk
+        run: |
+          echo "Listing generated APKs in demos/android directory:"
+          ls -l demos/android/*.apk || echo "No APKs found."
 
       - name: Upload APKs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -15,26 +15,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: set up JDK 17
+      - name: Clone MASTestApp-Android repository
+        run: git clone https://github.com/cpholguera/MASTestApp-Android.git
+
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
 
-      - name: Clone MASTestApp-Android repository
-        run: git clone https://github.com/cpholguera/MASTestApp-Android.git
-
       - name: Replace files and build APKs
         run: |
           for demo in demos/android/MASTG-DEMO-*; do
             if [ -d "$demo" ]; then
-              cp -f $demo/MastgTest.kt MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt || true
-              cp -f $demo/AndroidManifest.xml MASTestApp-Android/app/src/main/AndroidManifest.xml || true
+              cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt || true
+              cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml || true
               cd MASTestApp-Android
               ./gradlew assembleDebug
               cd ..
-              mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk $demo.apk
+              mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk"
             fi
           done
 

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -1,0 +1,43 @@
+name: Build Android Demos
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+
+      - name: Clone MASTestApp-Android repository
+        run: git clone https://github.com/cpholguera/MASTestApp-Android.git
+
+      - name: Replace files and build APKs
+        run: |
+          for demo in demos/android/MASTG-DEMO-*; do
+            if [ -d "$demo" ]; then
+              cp -f $demo/MastgTest.kt MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt || true
+              cp -f $demo/AndroidManifest.xml MASTestApp-Android/app/src/main/AndroidManifest.xml || true
+              cd MASTestApp-Android
+              ./gradlew assembleDebug
+              cd ..
+              mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk $demo.apk
+            fi
+          done
+
+      - name: Upload APKs
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-demos-apks
+          path: demos/android/*.apk

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -24,55 +24,37 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
 
-      - name: Copy MastgTest.kt
+      - name: Replace files and build APK
         run: |
           demo="demos/android/MASVS-CRYPTO/MASTG-DEMO-0007"
           if [ -d "$demo" ]; then
-            if [ -f "$demo/MastgTest.kt" ]; then
-              echo "Copying MastgTest.kt for $demo"
-              cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt
+            echo "Processing $demo"
+            [ -f "$demo/MastgTest.kt" ] && cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt && echo "Copied MastgTest.kt for $demo" || echo "No MastgTest.kt found for $demo"
+            [ -f "$demo/AndroidManifest.xml" ] && cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml && echo "Copied AndroidManifest.xml for $demo" || echo "No AndroidManifest.xml found for $demo"
+            cd MASTestApp-Android
+            echo "Building APK for $demo"
+            ./gradlew assembleDebug --stacktrace
+            build_status=$?
+            cd ..
+            if [ $build_status -eq 0 ]; then
+              echo "Build succeeded for $demo"
+              if [ -f "MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk" ]; then
+                mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk"
+                echo "APK for $demo moved to $demo.apk"
+              else
+                echo "APK not found for $demo"
+              fi
             else
-              echo "No MastgTest.kt found for $demo"
+              echo "Build failed for $demo"
             fi
           else
             echo "Demo directory not found: $demo"
           fi
 
-      - name: Copy AndroidManifest.xml
-        run: |
-          demo="demos/android/MASVS-CRYPTO/MASTG-DEMO-0007"
-          if [ -d "$demo" ]; then
-            if [ -f "$demo/AndroidManifest.xml" ]; then
-              echo "Copying AndroidManifest.xml for $demo"
-              cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml
-            else
-              echo "No AndroidManifest.xml found for $demo"
-            fi
-          else
-            echo "Demo directory not found: $demo"
-          fi
-
-      - name: Build APK
-        run: |
-          demo="demos/android/MASVS-CRYPTO/MASTG-DEMO-0007"
-          cd MASTestApp-Android
-          echo "Building APK for $demo"
-          ./gradlew assembleDebug --stacktrace
-          build_status=$?
-          cd ..
-          if [ $build_status -eq 0 ]; then
-            echo "Build succeeded for $demo"
-            if [ -f "MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk" ]; then
-              mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk"
-              echo "APK for $demo moved to $demo.apk"
-            else
-              echo "APK not found for $demo"
-            fi
-          else
-            echo "Build failed for $demo"
-          fi
+      - name: Set APK name variable
+        id: set_apk_name
+        run: echo "APK_NAME=$(basename demos/android/MASVS-CRYPTO/MASTG-DEMO-0007.apk)" >> $GITHUB_ENV
 
       - name: List generated APK
         run: |
@@ -82,5 +64,5 @@ jobs:
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: android-demo-apk
+          name: ${{ env.APK_NAME }}
           path: demos/android/MASVS-CRYPTO/MASTG-DEMO-0007.apk

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -28,7 +28,7 @@ jobs:
           done
           matrix="${matrix%,}]}"
           echo "matrix=$matrix" >> $GITHUB_ENV
-          echo "::set-output name=matrix::$matrix"
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
 
       - name: Print matrix
         run: echo "${{ steps.set-matrix.outputs.matrix }}"
@@ -36,9 +36,11 @@ jobs:
   build:
     needs: generate-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 60  # Increase this value as needed
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-
+      max-parallel: 3  # Limit the number of parallel jobs
+    
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -31,16 +31,31 @@ jobs:
           for demo in demos/android/MASTG-DEMO-*; do
             if [ -d "$demo" ]; then
               echo "Processing $demo"
-              cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt || true
-              cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml || true
+              if [ -f "$demo/MastgTest.kt" ]; then
+                echo "Copying MastgTest.kt for $demo"
+                cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt
+              else
+                echo "No MastgTest.kt found for $demo"
+              fi
+              if [ -f "$demo/AndroidManifest.xml" ]; then
+                echo "Copying AndroidManifest.xml for $demo"
+                cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml
+              else
+                echo "No AndroidManifest.xml found for $demo"
+              fi
               cd MASTestApp-Android
+              echo "Building APK for $demo"
               ./gradlew assembleDebug
               build_status=$?
               cd ..
               if [ $build_status -eq 0 ]; then
                 echo "Build succeeded for $demo"
-                mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk" || echo "Failed to move APK for $demo"
-                echo "APK for $demo moved to $demo.apk"
+                if [ -f "MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk" ]; then
+                  mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk"
+                  echo "APK for $demo moved to $demo.apk"
+                else
+                  echo "APK not found for $demo"
+                fi
               else
                 echo "Build failed for $demo"
               fi

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -1,4 +1,4 @@
-name: Build Android Demos
+name: Build Single Android Demo
 
 on:
   push:
@@ -26,49 +26,61 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Replace files and build APKs
+      - name: Copy MastgTest.kt
         run: |
-          for demo in demos/android/MASTG-DEMO-*; do
-            if [ -d "$demo" ]; then
-              echo "Processing $demo"
-              if [ -f "$demo/MastgTest.kt" ]; then
-                echo "Copying MastgTest.kt for $demo"
-                cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt
-              else
-                echo "No MastgTest.kt found for $demo"
-              fi
-              if [ -f "$demo/AndroidManifest.xml" ]; then
-                echo "Copying AndroidManifest.xml for $demo"
-                cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml
-              else
-                echo "No AndroidManifest.xml found for $demo"
-              fi
-              cd MASTestApp-Android
-              echo "Building APK for $demo"
-              ./gradlew assembleDebug
-              build_status=$?
-              cd ..
-              if [ $build_status -eq 0 ]; then
-                echo "Build succeeded for $demo"
-                if [ -f "MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk" ]; then
-                  mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk"
-                  echo "APK for $demo moved to $demo.apk"
-                else
-                  echo "APK not found for $demo"
-                fi
-              else
-                echo "Build failed for $demo"
-              fi
+          demo="demos/android/MASVS-CRYPTO/MASTG-DEMO-0007"
+          if [ -d "$demo" ]; then
+            if [ -f "$demo/MastgTest.kt" ]; then
+              echo "Copying MastgTest.kt for $demo"
+              cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt
+            else
+              echo "No MastgTest.kt found for $demo"
             fi
-          done
+          else
+            echo "Demo directory not found: $demo"
+          fi
 
-      - name: List generated APKs
+      - name: Copy AndroidManifest.xml
         run: |
-          echo "Listing generated APKs in demos/android directory:"
-          ls -l demos/android/*.apk || echo "No APKs found."
+          demo="demos/android/MASVS-CRYPTO/MASTG-DEMO-0007"
+          if [ -d "$demo" ]; then
+            if [ -f "$demo/AndroidManifest.xml" ]; then
+              echo "Copying AndroidManifest.xml for $demo"
+              cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml
+            else
+              echo "No AndroidManifest.xml found for $demo"
+            fi
+          else
+            echo "Demo directory not found: $demo"
+          fi
 
-      - name: Upload APKs
+      - name: Build APK
+        run: |
+          demo="demos/android/MASVS-CRYPTO/MASTG-DEMO-0007"
+          cd MASTestApp-Android
+          echo "Building APK for $demo"
+          ./gradlew assembleDebug --stacktrace
+          build_status=$?
+          cd ..
+          if [ $build_status -eq 0 ]; then
+            echo "Build succeeded for $demo"
+            if [ -f "MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk" ]; then
+              mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk"
+              echo "APK for $demo moved to $demo.apk"
+            else
+              echo "APK not found for $demo"
+            fi
+          else
+            echo "Build failed for $demo"
+          fi
+
+      - name: List generated APK
+        run: |
+          echo "Listing generated APK in demos/android directory:"
+          ls -l demos/android/MASVS-CRYPTO/MASTG-DEMO-0007.apk || echo "No APK found."
+
+      - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
-          name: android-demos-apks
-          path: demos/android/*.apk
+          name: android-demo-apk
+          path: demos/android/MASVS-CRYPTO/MASTG-DEMO-0007.apk

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -1,6 +1,7 @@
-name: Build Single Android Demo
+name: Build All Android Demos
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -9,8 +10,34 @@ on:
       - master
 
 jobs:
-  build:
+  generate-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate matrix
+        id: set-matrix
+        run: |
+          demos=$(find demos/android -type d -name "MASTG-DEMO-*")
+          matrix="{\"demo\":["
+          for demo in $demos; do
+            matrix="${matrix}\"$demo\","
+          done
+          matrix="${matrix%,}]}"
+          echo "matrix=$matrix" >> $GITHUB_ENV
+          echo "::set-output name=matrix::$matrix"
+
+      - name: Print matrix
+        run: echo "${{ steps.set-matrix.outputs.matrix }}"
+
+  build:
+    needs: generate-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
 
     steps:
       - name: Checkout repository
@@ -27,7 +54,7 @@ jobs:
 
       - name: Replace files and build APK
         run: |
-          demo="demos/android/MASVS-CRYPTO/MASTG-DEMO-0007"
+          demo="${{ matrix.demo }}"
           if [ -d "$demo" ]; then
             echo "Processing $demo"
             [ -f "$demo/MastgTest.kt" ] && cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt && echo "Copied MastgTest.kt for $demo" || echo "No MastgTest.kt found for $demo"
@@ -39,9 +66,10 @@ jobs:
             cd ..
             if [ $build_status -eq 0 ]; then
               echo "Build succeeded for $demo"
+              apk_name="$(basename "$demo").apk"
               if [ -f "MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk" ]; then
-                mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$demo.apk"
-                echo "APK for $demo moved to $demo.apk"
+                mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$apk_name"
+                echo "APK for $demo moved to $apk_name"
               else
                 echo "APK not found for $demo"
               fi
@@ -54,15 +82,15 @@ jobs:
 
       - name: Set APK name variable
         id: set_apk_name
-        run: echo "APK_NAME=$(basename demos/android/MASVS-CRYPTO/MASTG-DEMO-0007.apk)" >> $GITHUB_ENV
+        run: echo "APK_NAME=$(basename ${{ matrix.demo }}).apk" >> $GITHUB_ENV
 
       - name: List generated APK
         run: |
           echo "Listing generated APK in demos/android directory:"
-          ls -l demos/android/MASVS-CRYPTO/MASTG-DEMO-0007.apk || echo "No APK found."
+          ls -l "${{ env.APK_NAME }}" || echo "No APK found."
 
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APK_NAME }}
-          path: demos/android/MASVS-CRYPTO/MASTG-DEMO-0007.apk
+          path: "${{ env.APK_NAME }}"


### PR DESCRIPTION
Closes #2829

Add a new GitHub action to build APKs for each `MASTG-DEMO-XXXX` folder in the `demos/android` directory.

* Add a new workflow file `.github/workflows/build-android-demos.yml`.
* Clone the `MASTestApp-Android` repository.
* Replace `MastgTest.kt` and/or `AndroidManifest.xml` files in `MASTestApp-Android` if they exist in the demo folder.
* Build the APK for each demo folder.
* Upload the resulting APKs as artifacts with the name of the demo as the APK's name.