### PR TITLE
Fixes #2824

### DIFF
--- a/techniques/android/MASTG-TECH-0012.md
+++ b/techniques/android/MASTG-TECH-0012.md
@@ -13,7 +13,6 @@ This section describes various ways to bypass SSL Pinning and gives guidance abo
 
 There are several ways to bypass certificate pinning for a black box test, depending on the frameworks available on the device:
 
-- Cydia Substrate: Install the [Android-SSL-TrustKiller](https://github.com/iSECPartners/Android-SSL-TrustKiller "Android-SSL-TrustKiller") package.
 - Frida: Use the [frida-multiple-unpinning](https://codeshare.frida.re/@akabe1/frida-multiple-unpinning/ "Project: frida-multiple-unpinning") script.
 - Objection: Use the `android sslpinning disable` command.
 - Xposed: Install the [TrustMeAlready](https://github.com/ViRb3/TrustMeAlready "TrustMeAlready") or [SSLUnpinning](https://github.com/ac-pm/SSLUnpinning_Xposed "SSLUnpinning") module.
@@ -29,6 +28,8 @@ Here's an example of the output:
 <img src="Images/Chapters/0x05b/android_ssl_pinning_bypass.png" width="100%" />
 
 See also [Objection's help on Disabling SSL Pinning for Android](https://github.com/sensepost/objection/blob/master/objection/console/helpfiles/android.sslpinning.disable.txt) for further information and inspect the [pinning.ts](https://github.com/sensepost/objection/blob/master/agent/src/android/pinning.ts "pinning.ts") file to understand how the bypass works.
+
+Note that the frida-multiple-unpinning script from @MASTG-TOOL-0032 covers more scenarios than the Objection script.
 
 ## Bypass Custom Certificate Pinning Statically
 

--- a/tools/generic/MASTG-TOOL-0032.md
+++ b/tools/generic/MASTG-TOOL-0032.md
@@ -4,12 +4,16 @@ platform: generic
 source: https://codeshare.frida.re/
 ---
 
-[Frida CodeShare](https://codeshare.frida.re/ "Frida CodeShare") is a repository containing a collection of ready-to-run Frida scripts which can enormously help when performing concrete tasks both on Android as on iOS as well as also serve as inspiration to build your own scripts. Two representative examples are:
+[Frida CodeShare](https://codeshare.frida.re/ "Frida CodeShare") is a repository containing a collection of ready-to-run Frida scripts which can enormously help when performing concrete tasks both on Android as on iOS as well as also serve as inspiration to build your own scripts. Some examples of useful scripts:
 
-- Universal Android SSL Pinning Bypass with Frida - <https://codeshare.frida.re/@pcipolloni/universal-android-ssl-pinning-bypass-with-frida/>
+- Frida Multiple Unpinning - <https://codeshare.frida.re/@akabe1/frida-multiple-unpinning/>
+- Disable Flutter TLS verification - <https://codeshare.frida.re/@TheDauntless/disable-flutter-tls-v1/>
 - ObjC method observer - <https://codeshare.frida.re/@mrmacete/objc-method-observer/>
+- JNI Trace - <https://codeshare.frida.re/@chame1eon/jnitrace/>
+- Dump dynamically loaded DEX - <https://codeshare.frida.re/@cryptax/inmemorydexclassloader-dump/>
+- Enable iOS WebInspector - <https://codeshare.frida.re/@leolashkevych/ios-enable-webinspector/>
 
-Using them is as simple as including the `--codeshare <handler>` flag and a handler when using the Frida CLI. For example, to use "ObjC method observer", enter the following:
+Using them is as simple as including the `--codeshare <script>` flag with the chosen script when using the Frida CLI. For example, to use "ObjC method observer", enter the following:
 
 ```bash
 frida --codeshare mrmacete/objc-method-observer -f YOUR_BINARY


### PR DESCRIPTION
A fix for #2824 

We can still add separate pages in the future and then link to those pages from the list on this page. I mostly wanted to already remove the very outdated references for SSL pinning.