### PR TITLE
defined variables can't contain dashes

### DIFF
--- a/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0084.md
+++ b/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0084.md
@@ -48,7 +48,7 @@ In Objective-C, developers can use preprocessor macros to filter out debug code:
 
 In Swift 2 (with Xcode 7), you have to set custom compiler flags for every target, and compiler flags have to start with "-D". So you can use the following annotations when the debug flag `DMSTG-DEBUG` is set:
 
-```default
+```objectivec
 #if MSTG_DEBUG
     // Debug-only code
 #endif
@@ -56,7 +56,7 @@ In Swift 2 (with Xcode 7), you have to set custom compiler flags for every targe
 
 In Swift 3 (with Xcode 8), you can set Active Compilation Conditions in Build settings/Swift compiler - Custom flags. Instead of a preprocessor, Swift 3 uses [conditional compilation blocks](https://developer.apple.com/library/content/documentation/Swift/Conceptual/BuildingCocoaApps/InteractingWithCAPIs.html#//apple_ref/doc/uid/TP40014216-CH8-ID34 "Swift conditional compilation blocks") based on the defined conditions:
 
-```default
+```objectivec
 #if DEBUG_LOGGING
     // Debug-only code
 #endif

--- a/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0084.md
+++ b/tests/ios/MASVS-RESILIENCE/MASTG-TEST-0084.md
@@ -49,7 +49,7 @@ In Objective-C, developers can use preprocessor macros to filter out debug code:
 In Swift 2 (with Xcode 7), you have to set custom compiler flags for every target, and compiler flags have to start with "-D". So you can use the following annotations when the debug flag `DMSTG-DEBUG` is set:
 
 ```default
-#if MSTG-DEBUG
+#if MSTG_DEBUG
     // Debug-only code
 #endif
 ```


### PR DESCRIPTION
Maybe good to reference this document for Swift developemtn https://www.swiftbysundell.com/articles/using-compiler-directives-in-swift/

Thank you for submitting a Pull Request to the OWASP MASTG. Please make sure that:

- [ ] Your contribution is written in the 2nd person (e.g. you)
- [ ] Your contribution is written in an active present form for as much as possible.
- [ ] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [ ] Your contribution has proper formatted markdown and/or code
- [ ] Any references to website have been formatted as [TEXT](URL “NAME”)
- [ ] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

If your PR is related to an issue. Please end your PR test with the following line:
This PR closes #< insert number here >.
