### PR TITLE
Update MASTG-TECH-0054.md

### DIFF
--- a/techniques/ios/MASTG-TECH-0054.md
+++ b/techniques/ios/MASTG-TECH-0054.md
@@ -58,7 +58,7 @@ In order to retrieve the unencrypted version, you can use [frida-ios-dump](https
 
 First, configure @MASTG-TOOL-0054 `dump.py`:
 
-- set it to use `localhost` with port `2222` when using @MASTG-TOOL-0055, or to the actual IP address and port of the device from which you want to dump the binary.
+- set it to use `localhost` with port `2222` when using @MASTG-TOOL-0055 (`iproxy 2222 22`), or to the actual IP address and port of the device from which you want to dump the binary. 
 - update the default username (`User = 'root'`) and password (`Password = 'alpine'`) in `dump.py` to the ones you have set.
 
 Enumerate the apps installed on the device by running `python dump.py -l`:
@@ -74,7 +74,7 @@ Enumerate the apps installed on the device by running `python dump.py -l`:
    ...
 ```
 
-You can dump the selected app, for example Telegram, by running `python dump.py ph.telegra.Telegraph`
+You can dump the selected app, for example Telegram, by running `python dump.py -H 127.0.0.1 -p 2222 --user mobile -P alpine ph.telegra.Telegraph`, if you are using a SSH tunnel with `iproxy` and the default credentials on a jailbroken phone.
 
 After a couple of seconds, the `Telegram.ipa` file will be created in your current directory. You can validate the success of the dump by removing the app and reinstalling it (e.g. using @MASTG-TOOL-0054 `ios-deploy -b Telegram.ipa`). Note that this will only work on jailbroken devices, as otherwise the signature won't be valid.
 

--- a/techniques/ios/MASTG-TECH-0054.md
+++ b/techniques/ios/MASTG-TECH-0054.md
@@ -58,7 +58,7 @@ In order to retrieve the unencrypted version, you can use [frida-ios-dump](https
 
 First, configure @MASTG-TOOL-0054 `dump.py`:
 
-- set it to use `localhost` with port `2222` when using @MASTG-TOOL-0055 (`iproxy 2222 22`), or to the actual IP address and port of the device from which you want to dump the binary. 
+- set it to use `localhost` with port `2222` when using @MASTG-TOOL-0055 (`iproxy 2222 22`), or to the actual IP address and port of the device from which you want to dump the binary.
 - update the default username (`User = 'root'`) and password (`Password = 'alpine'`) in `dump.py` to the ones you have set.
 
 Enumerate the apps installed on the device by running `python dump.py -l`:

--- a/techniques/ios/MASTG-TECH-0054.md
+++ b/techniques/ios/MASTG-TECH-0054.md
@@ -74,7 +74,7 @@ Enumerate the apps installed on the device by running `python dump.py -l`:
    ...
 ```
 
-You can dump the selected app, for example Telegram, by running `python dump.py -H 127.0.0.1 -p 2222 --user mobile -P alpine ph.telegra.Telegraph`, if you are using a SSH tunnel with `iproxy` and the default credentials on a jailbroken phone.
+You can dump the selected app, for example Telegram, by running `python dump.py -H 127.0.0.1 -p 2222 --user mobile -P alpine ph.telegra.Telegraph`, if you are using an SSH tunnel with `iproxy` and the default credentials on a jailbroken phone.
 
 After a couple of seconds, the `Telegram.ipa` file will be created in your current directory. You can validate the success of the dump by removing the app and reinstalling it (e.g. using @MASTG-TOOL-0054 `ios-deploy -b Telegram.ipa`). Note that this will only work on jailbroken devices, as otherwise the signature won't be valid.
 


### PR DESCRIPTION
Changes for [techniques/ios/MASTG-TECH-0054.md](https://github.com/OWASP/owasp-mastg/blob/3175d39374e91590ec802d8a787cb2b73e7d8a32/techniques%2Fios%2FMASTG-TECH-0054.md):

- Modified the instruction to set `dump.py` to use `localhost` with port `2222` when using `@MASTG-TOOL-0055` by specifying the use of `iproxy 2222 22`.
- Updated the command for dumping the Telegram app to include options `-H 127.0.0.1 -p 2222 --user mobile -P alpine`, explicitly mentioning the use of an SSH tunnel with `iproxy` and default credentials on a jailbroken phone.

