### PR TITLE
Improve Android backup extract commands

### DIFF
--- a/tests/android/MASVS-STORAGE/MASTG-TEST-0009.md
+++ b/tests/android/MASVS-STORAGE/MASTG-TEST-0009.md
@@ -74,13 +74,13 @@ Approve the backup from your device by selecting the _Back up my data_ option. A
 Run the following command to convert the .ab file to tar.
 
 ```bash
-dd if=mybackup.ab bs=24 skip=1|openssl zlib -d > mybackup.tar
+tail -c +25 backup.ab |openssl zlib -d > backup.tar
 ```
 
 In case you get the error `openssl:Error: 'zlib' is an invalid command.` you can try to use Python instead.
 
 ```bash
-dd if=backup.ab bs=1 skip=24 | python -c "import zlib,sys;sys.stdout.write(zlib.decompress(sys.stdin.read()))" > backup.tar
+tail -c +25 backup.ab | python -c "import zlib,sys;sys.stdout.buffer.write(zlib.decompress(sys.stdin.buffer.read()))" > backup.tar
 ```
 
 The [_Android Backup Extractor_](https://github.com/nelenkov/android-backup-extractor "Android Backup Extractor") is another alternative backup tool. To make the tool to work, you have to download the Oracle JCE Unlimited Strength Jurisdiction Policy Files for [JRE7](https://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html "Oracle JCE Unlimited Strength Jurisdiction Policy Files JRE7") or [JRE8](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html "Oracle JCE Unlimited Strength Jurisdiction Policy Files JRE8") and place them in the JRE lib/security folder. Run the following command to convert the tar file:
@@ -104,5 +104,5 @@ java -jar abe.jar unpack backup.ab backup.tar 123
 Extract the tar file to your working directory.
 
 ```bash
-tar xvf mybackup.tar
+tar xvf backup.tar
 ```


### PR DESCRIPTION
The previous commands used dd with a small block-size, slowing down the process unnecessarily. Tail accomplishes the same results much faster. 

In addition, the python command tries to decode the content in Python 3. The new commands read and write from/to buffers instead to operate on binary data.

Thank you for submitting a Pull Request to the OWASP MASTG. Please make sure that:

- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)
