### PR TITLE
Fix typo MASTG-TOOL-0122 title name

### DIFF
--- a/tools/ios/MASTG-TOOL-0122.md
+++ b/tools/ios/MASTG-TOOL-0122.md
@@ -1,6 +1,10 @@
 ---
-title: c++file
+title: c++filt
 platform: ios
+host:
+- macos
+- windows
+- linux
 ---
 
 [c++filt](https://www.gnu.org/software/binutils/ "GNU Binutils") is a demangling tool that converts mangled C++ symbols into human readable strings by calling `c++filt <symbol>`. See [the man page](https://ftp.gnu.org/old-gnu/Manuals/binutils-2.12/html_node/binutils_11.html "c++filt") for more information on its usage.


### PR DESCRIPTION
Fix a typo in a recently added tool name