### PR TITLE
Add libimobiledevice / update iproxy (@NVISOSecurity)

### DIFF
--- a/Document/0x06b-iOS-Security-Testing.md
+++ b/Document/0x06b-iOS-Security-Testing.md
@@ -37,10 +37,9 @@ It is also possible to get the UDID via various command line tools on macOS whil
     |         "USB Serial Number" = "9e8ada44246cee813e2f8c1407520bf2f84849ec"
     ```
 
-- By using [ideviceinstaller](https://github.com/libimobiledevice/ideviceinstaller) (also available on Linux):
+- By using @MASTG-TOOL-0126:
 
     ```sh
-    $ brew install ideviceinstaller
     $ idevice_id -l
     316f01bd160932d2bf2f95f1f142bc29b1c62dbc
     ```

--- a/techniques/ios/MASTG-TECH-0052.md
+++ b/techniques/ios/MASTG-TECH-0052.md
@@ -50,7 +50,6 @@ During a real black box test, a reliable Wi-Fi connection may not be available. 
 Connect macOS to an iOS device by installing and starting @MASTG-TOOL-0055:
 
 ```bash
-$ brew install libimobiledevice
 $ iproxy 2222 22
 waiting for connection
 ```
@@ -60,12 +59,10 @@ The above command maps port `22` on the iOS device to port `2222` on localhost. 
 With the following command in a new terminal window, you can connect to the device:
 
 ```bash
-$ ssh -p 2222 root@localhost
-root@localhost's password:
-iPhone:~ root#
+$ ssh -p 2222 mobile@localhost
+mobile@localhost's password:
+iPhone:~ mobile%
 ```
-
-> Small note on USB of an iDevice: on an iOS device you cannot make data connections anymore after 1 hour of being in a locked state, unless you unlock it again due to the USB Restricted Mode, which was introduced with iOS 11.4.1
 
 ## On-device Shell App
 

--- a/techniques/ios/MASTG-TECH-0063.md
+++ b/techniques/ios/MASTG-TECH-0063.md
@@ -23,7 +23,7 @@ waiting for connection
 The next step is to make a remote port forwarding of port 8080 on the iOS device to the localhost interface on our computer to port 8080.
 
 ```bash
-ssh -R 8080:localhost:8080 root@localhost -p 2222
+ssh -R 8080:localhost:8080 mobile@localhost -p 2222
 ```
 
 You should now be able to reach Burp on your iOS device. Open Safari on iOS and go to 127.0.0.1:8080 and you should see the Burp Suite Page. This would also be a good time to [install the CA certificate](https://support.portswigger.net/customer/portal/articles/1841109-installing-burp-s-ca-certificate-in-an-ios-device "Installing Burp\'s CA Certificate in an iOS Device") of Burp on your iOS device.

--- a/tools/ios/MASTG-TOOL-0055.md
+++ b/tools/ios/MASTG-TOOL-0055.md
@@ -1,7 +1,11 @@
 ---
 title: iProxy
 platform: ios
-source: https://github.com/tcurdt/iProxy
+source: https://github.com/libimobiledevice/libusbmuxd
 ---
 
-A tool used to connect via SSH to a jailbroken iPhone via USB - <https://github.com/tcurdt/iProxy>
+iProxy allows you to forward a port from a connected iOS device to a port on the host machine. iProxy can be useful for interacting with jailbroken devices, as some jailbreaks do not expose the SSH port on the public interface. With iProxy, the SSH port can be forwarded over USB to the host, allowing you to still connect to it.
+
+!!! warning
+
+    While many package repositories (apt, brew, cargo, ...) have versions of libimobiledevice tools, they are often outdated. We recommend compiling the different tools from source for the best results.

--- a/tools/ios/MASTG-TOOL-0126.md
+++ b/tools/ios/MASTG-TOOL-0126.md
@@ -1,0 +1,42 @@
+---
+title: libimobiledevice suite
+platform: ios
+host:
+- macOS
+- windows
+- linux
+source: https://libimobiledevice.org/
+---
+
+The libimobiledevice suite is cross-platform protocol library for interacting with iOS devices. The different libraries can be compiled into binaries for direct interaction with iOS devices from the commandline.
+
+!!! warning
+
+    While many package repositories (apt, brew, cargo, ...) have versions of libimobiledevice tools, they are often outdated. We recommend compiling the different tools from source for the best results.
+
+The following tools are part of the libimobiledevice suite:
+
+| Tool | Purpose |
+|------------------|---------------------|
+| idevice_id | List attached devices or print device name of given device. |
+| idevicebackup | Create or restore backup from the current or specified directory (<iOS 4). |
+| idevicebackup2 | Create or restore backup from the current or specified directory (>= iOS 4). |
+| idevicecrashreport | Move crash reports from device to a local DIRECTORY. |
+| idevicedate | Display the current date or set it on a device. |
+| idevicedebug | Interact with the debugserver service of a device. |
+| idevicedebugserverproxy | Proxy debugserver connection from device to a local socket at PORT. |
+| idevicediagnostics | Use diagnostics interface of a device running iOS 4 or later. |
+| ideviceenterrecovery | Makes a device with the supplied UDID enter recovery mode immediately. |
+| ideviceimagemounter | Mounts the specified disk image on the device. |
+| ideviceinfo | Show information about a connected device. |
+| ideviceinstaller | Manage apps on iOS devices. |
+| idevicename | Display the device name or set it to NAME if specified. |
+| idevicenotificationproxy | Post or observe notifications on a device. |
+| idevicepair | Manage host pairings with devices and usbmuxd. |
+| ideviceprovision | Manage provisioning profiles on a device. |
+| idevicescreenshot | Gets a screenshot from a device. |
+| idevicesetlocation | Sets the location on a device. |
+| idevicesyslog | Relay syslog of a connected device. |
+| inetcat | Opens a read/write interface via STDIN/STDOUT to a TCP port on a usbmux device. |
+| iproxy | Proxy that binds local TCP ports to be forwarded to the specified ports on a usbmux device. |
+| plistutil | Convert a plist FILE between binary, XML, JSON, and OpenStep format. |


### PR DESCRIPTION
Added new tool page for libimobiledevice with an overview of all the available tools.

iproxy currently still has its own page (TOOL-0055) because it was already there. I don't mind having a general page for the libimobiledevice suite and splitting off a tool if useful, but let me know what you think.