### PR TITLE
Update MASTG-TEST-0228 to remove a step that isn't needed

### DIFF
--- a/tests-beta/ios/MASVS-CODE/MASTG-TEST-0228.md
+++ b/tests-beta/ios/MASVS-CODE/MASTG-TEST-0228.md
@@ -20,8 +20,7 @@ This test case checks if the main executable is compiled with PIE.
 ## Steps
 
 1. Extract the application and identify the main binary (@MASTG-TECH-0054).
-2. Identify all shared libraries (@MASTG-TECH-0082).
-3. Run @MASTG-TECH-0118 on the main binary and grep for "pic" or the corresponding keyword used by the selected tool.
+2. Run @MASTG-TECH-0118 on the main binary and grep for "pic" or the corresponding keyword used by the selected tool.
 
 ## Observation
 


### PR DESCRIPTION
Removed 2nd bullet point of the list because was referring to shared libraries while the test focus only on the binary.

Note: I discussed about that with Carlos directly on Slack.

> The test indicates:
>   - “Shared libraries (dylibs and frameworks) are inherently position-independent (PIE)”
>   - “This test case checks if the main executable is compiled with PIE.”
>   So we just need to check the main binary on iOS.


