### PR TITLE
Add GitHub Actions workflow to build iOS demos (by @NowSecure)

### DIFF
--- a/.github/workflows/build-ios-demos.yml
+++ b/.github/workflows/build-ios-demos.yml
@@ -1,0 +1,124 @@
+name: Build All iOS Demos
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - 'demos/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'demos/**'
+
+jobs:
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate matrix
+        id: set-matrix
+        run: |
+          demos=$(find demos/ios -type d -name "MASTG-DEMO-*")
+          matrix="{\"demo\":["
+          for demo in $demos; do
+            matrix="${matrix}\"$demo\","
+          done
+          matrix="${matrix%,}]}"
+          echo "matrix=$matrix" >> $GITHUB_ENV
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+      - name: Print matrix
+        run: echo "${{ steps.set-matrix.outputs.matrix }}"
+
+  build:
+    needs: generate-matrix
+    runs-on: macos-latest
+    timeout-minutes: 60
+    strategy:
+      matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+      max-parallel: 3
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Clone MASTestApp-iOS repository
+        run: git clone https://github.com/cpholguera/MASTestApp-iOS.git
+
+      - name: Install dependencies
+        run: |
+          brew install ldid cocoapods
+          pod install --repo-update || true
+
+      - name: Replace files and prepare build
+        run: |
+          demo="${{ matrix.demo }}"
+          if [ -d "$demo" ]; then
+            echo "Processing $demo"
+            [ -f "$demo/MastgTest.swift" ] && cp -f "$demo/MastgTest.swift" MASTestApp-iOS/MASTestApp/MastgTest.swift && echo "Copied MastgTest.swift for $demo" || echo "No MastgTest.swift found for $demo"
+            [ -f "$demo/Info.plist" ] && cp -f "$demo/Info.plist" MASTestApp-iOS/MASTestApp/Info.plist && echo "Copied Info.plist for $demo" || echo "No Info.plist found for $demo"
+          else
+            echo "Demo directory not found: $demo"
+            exit 1
+          fi
+
+      - name: Set iOS Deployment Target to 14.4
+        run: |
+          /usr/libexec/PlistBuddy -c "Set :objects:CBFA8C102BDE94720047F3A3:buildSettings:IPHONEOS_DEPLOYMENT_TARGET 14.4" "MASTestApp-iOS/MASTestApp.xcodeproj/project.pbxproj"
+          /usr/libexec/PlistBuddy -c "Set :objects:CBFA8C112BDE94720047F3A3:buildSettings:IPHONEOS_DEPLOYMENT_TARGET 14.4" "MASTestApp-iOS/MASTestApp.xcodeproj/project.pbxproj"
+          /usr/libexec/PlistBuddy -c "Set :objects:CBFA8C132BDE94720047F3A3:buildSettings:IPHONEOS_DEPLOYMENT_TARGET 14.4" "MASTestApp-iOS/MASTestApp.xcodeproj/project.pbxproj"
+          /usr/libexec/PlistBuddy -c "Set :objects:CBFA8C142BDE94720047F3A3:buildSettings:IPHONEOS_DEPLOYMENT_TARGET 14.4" "MASTestApp-iOS/MASTestApp.xcodeproj/project.pbxproj"
+          echo "iOS Deployment Target successfully updated to 14.4"
+
+      - name: Set Default Scheme
+        run: |
+          scheme_list=$(xcodebuild -list -json | tr -d "\n")
+          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo "DEFAULT_SCHEME=$default" >> $GITHUB_ENV
+          echo "Using default scheme: $default"
+
+      - name: Build the app (unsigned)
+        run: |
+          xcodebuild archive \
+            -project "MASTestApp-iOS/MASTestApp.xcodeproj" \
+            -scheme "$DEFAULT_SCHEME" \
+            -archivePath "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive" \
+            -configuration Release \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Add Entitlements
+        run: |
+          ldid -Sentitlements.plist "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app/MASTestApp"
+
+      - name: Create IPA manually
+        run: |
+          cd "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products" || exit
+          mv Applications Payload
+          zip -r9q MASTestApp.zip Payload
+          mv MASTestApp.zip MASTestApp.ipa
+          mkdir -p "$GITHUB_WORKSPACE/output"
+          mv MASTestApp.ipa "$GITHUB_WORKSPACE/output/MASTestApp-unsigned.ipa"
+
+      - name: Set IPA name variable
+        id: set_ipa_name
+        run: echo "IPA_NAME=$(basename ${{ matrix.demo }}).ipa" >> $GITHUB_ENV
+
+      - name: List generated IPA
+        run: |
+          echo "Listing generated IPA in output directory:"
+          ls -l "$GITHUB_WORKSPACE/output/${{ env.IPA_NAME }}" || echo "No IPA found."
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.IPA_NAME }}
+          path: "$GITHUB_WORKSPACE/output/${{ env.IPA_NAME }}"


### PR DESCRIPTION
### **Automate iOS Demos Build with GitHub Actions**

#### **Summary**
This PR introduces a GitHub Actions workflow to automate the build process for all iOS demo applications. The workflow dynamically discovers demo projects and generates unsigned `.ipa` files that can be downloaded and tested on jailbroken devices.

#### **Key Features**
- **Automatic Discovery:**  
  - Finds all demo directories under `demos/ios/` matching the pattern `MASTG-DEMO-*`.
  - Builds each demo separately using a dynamic matrix strategy.

- **Build Process:**
  - Installs necessary dependencies (`ldid`, `cocoapods`).
  - Replaces required project files (e.g., `MastgTest.swift`, `Info.plist`) from each demo.
  - Updates the iOS deployment target to **14.4** for compatibility.
  - Compiles the project with Xcode without code signing.
  - Manually packages the app into an `.ipa` file.

- **Artifact Upload:**  
  - The generated IPA files are uploaded as workflow artifacts for easy downloading and testing.

#### **Trigger Conditions**
- The workflow is triggered when:
  - Changes are made to the `demos/**` directory.
  - A pull request is opened against the `master` branch.
  - It is manually triggered via the GitHub Actions UI.

#### **Parallelization**
- The build process supports parallel execution (up to 3 demos at a time), improving build efficiency.

#### **How to Use**
1. Add or modify iOS demo projects in the `demos/ios/` directory.
2. Push changes to the repository or open a pull request.
3. Download the generated `.ipa` files from the GitHub Actions "Artifacts" section.
