### PR TITLE
Update CWE mapping on MASWE elements of MASVS-AUTH-3

### DIFF
--- a/weaknesses/MASVS-AUTH/MASWE-0028.md
+++ b/weaknesses/MASVS-AUTH/MASWE-0028.md
@@ -7,6 +7,7 @@ profiles: [L2]
 mappings:
   masvs-v1: [MSTG-AUTH-9]
   masvs-v2: [MASVS-AUTH-3]
+  cwe: [287]
 
 draft:
   description: e.g. not using auto-fill

--- a/weaknesses/MASVS-AUTH/MASWE-0030.md
+++ b/weaknesses/MASVS-AUTH/MASWE-0030.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L2]
 mappings:
   masvs-v2: [MASVS-AUTH-3]
+  cwe: [285, 287]
 
 refs:
 - https://developers.google.com/identity/sign-in/android/disconnect

--- a/weaknesses/MASVS-AUTH/MASWE-0031.md
+++ b/weaknesses/MASVS-AUTH/MASWE-0031.md
@@ -6,6 +6,7 @@ platform: [android]
 profiles: [L2]
 mappings:
   masvs-v2: [MASVS-AUTH-3]
+  cwe: [287]
 
 draft:
   description: Android Protected Confirmation doesn't provide a secure information


### PR DESCRIPTION
- Update all CWE IDs on MASWE elements of MASVS-AUTH-3
- MASWE-0028 may also be related to **[CWE-308: Use of Single-factor Authentication](https://cwe.mitre.org/data/definitions/308.html)**  since "no MFA" can be considered a "MFA implementation lacking". To comprehend CWE-308 in the MASWE list, please consider change the title or add this as Relevant Topic of MASWE-0028, or add a new MASWE element.

This PR is related to issue #2858 .