### PR TITLE
Update CWE mapping on MASWE elements of MASVS-NETWORK-1

### DIFF
--- a/weaknesses/MASVS-NETWORK/MASWE-0048.md
+++ b/weaknesses/MASVS-NETWORK/MASWE-0048.md
@@ -7,6 +7,7 @@ profiles: [L1, L2]
 mappings:
   masvs-v1: [MSTG-NETWORK-1]
   masvs-v2: [MASVS-NETWORK-1]
+  cwe: [311, 319]
   android-risks:
     - https://developer.android.com/privacy-and-security/risks/insecure-machine-to-machine
 draft:

--- a/weaknesses/MASVS-NETWORK/MASWE-0051.md
+++ b/weaknesses/MASVS-NETWORK/MASWE-0051.md
@@ -7,6 +7,7 @@ profiles: [L2]
 mappings:
   masvs-v1: [MSTG-NETWORK-2]
   masvs-v2: [MASVS-NETWORK-1]
+  cwe: [923]
 status: new
 ---
 

--- a/weaknesses/MASVS-NETWORK/MASWE-0052.md
+++ b/weaknesses/MASVS-NETWORK/MASWE-0052.md
@@ -7,7 +7,7 @@ profiles: [L1, L2]
 mappings:
   masvs-v1: [MSTG-NETWORK-3]
   masvs-v2: [MASVS-NETWORK-1]
-  cwe: [295]
+  cwe: [295. 297]
   android-risks:
   - https://developer.android.com/privacy-and-security/risks/unsafe-trustmanager
   - https://developer.android.com/privacy-and-security/risks/unsafe-hostname


### PR DESCRIPTION
- Update all CWE IDs on MASWE elements of MASVS-NETWORK-1
- Skipped MASWE-0049 due to possible deprecation

This PR is related to issue #2858 .