### PR TITLE
Update CWE mapping on MASWE elements of MASVS-PLATFORM-3.

### DIFF
--- a/weaknesses/MASVS-PLATFORM/MASWE-0053.md
+++ b/weaknesses/MASVS-PLATFORM/MASWE-0053.md
@@ -7,6 +7,7 @@ profiles: [L2]
 mappings:
   masvs-v1: [MSTG-STORAGE-7]
   masvs-v2: [MASVS-PLATFORM-3, MASVS-STORAGE-2]
+  cwe: [200, 359]
 
 draft:
   description: e.g. leaking passwords, PINs via the UI

--- a/weaknesses/MASVS-PLATFORM/MASWE-0054.md
+++ b/weaknesses/MASVS-PLATFORM/MASWE-0054.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L2]
 mappings:
   masvs-v2: [MASVS-PLATFORM-3, MASVS-STORAGE-2]
+  cwe: [200, 359]
 
 draft:
   description: e.g. stealing pending intents from notifications via notificationlistenerservice

--- a/weaknesses/MASVS-PLATFORM/MASWE-0055.md
+++ b/weaknesses/MASVS-PLATFORM/MASWE-0055.md
@@ -7,6 +7,7 @@ profiles: [L2]
 mappings:
   masvs-v1: [MSTG-STORAGE-9]
   masvs-v2: [MASVS-PLATFORM-3, MASVS-STORAGE-2]
+  cwe: [200, 359]
 
 refs:
 - https://developer.android.com/about/versions/14/features/screenshot-detection

--- a/weaknesses/MASVS-PLATFORM/MASWE-0056.md
+++ b/weaknesses/MASVS-PLATFORM/MASWE-0056.md
@@ -7,6 +7,7 @@ profiles: [L2]
 mappings:
   masvs-v1: [MSTG-PLATFORM-9]
   masvs-v2: [MASVS-PLATFORM-3, MASVS-CODE-1]
+  cwe: [1021]
 
 refs:
 - https://developer.android.com/topic/security/risks/tapjacking

--- a/weaknesses/MASVS-PLATFORM/MASWE-0057.md
+++ b/weaknesses/MASVS-PLATFORM/MASWE-0057.md
@@ -6,6 +6,7 @@ platform: [android]
 profiles: [L1, L2]
 mappings:
   masvs-v2: [MASVS-PLATFORM-3]
+  cwe: [451, 1104]
 
 refs:
 - https://developer.android.com/topic/security/risks/strandhogg


### PR DESCRIPTION
- Update all CWE IDs on MASWE elements of MASVS-PLATFORM-3
- MASWE-0057 is missing because still under review; CWE-20: Improper Input Validation and CWE-284: Improper Access Control are suggested.

This PR is related to issue #2858 .