### PR TITLE
Fixed Missing Reversed Java Code in the MASTG-DEMO-0017

### DIFF
--- a/demos/android/MASVS-CRYPTO/MASTG-DEMO-0017/MASTG-DEMO-0017.md
+++ b/demos/android/MASVS-CRYPTO/MASTG-DEMO-0017/MASTG-DEMO-0017.md
@@ -9,7 +9,7 @@ code: [java]
 
 ### Sample
 
-{{ MastgTest.kt }}
+{{ MastgTest.kt # MastgTest_reversed.java }}
 
 ### Steps
 


### PR DESCRIPTION
For the demo of the test, MASTG-DEMO-0017: Use of Hardcoded AES Key in SecretKeySpec with semgrep, the reversed Java code in the Sample section is not rendered because the markdown file was missing the Java code filename. With this PR the filename is updated in the Sample section so that both the Kotlin code and reversed Java code are visible.