### PR TITLE
Update CWE mapping on MASWE elements of MASVS-RESILIENCE

### DIFF
--- a/weaknesses/MASVS-RESILIENCE/MASWE-0089.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0089.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-9]
   masvs-v2: [MASVS-RESILIENCE-3]
+  cwe: [657]
 
 draft:
   description: e.g. polymorphic obfuscation, method-inlining, insertion of opaque

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0090.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0090.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-11]
   masvs-v2: [MASVS-RESILIENCE-3]
+  cwe: [657]
 
 draft:
   description: e.g. resource obfuscation, binary encryption/packing

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0091.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0091.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-12]
   masvs-v2: [MASVS-RESILIENCE-3]
+  cwe: [657]
 
 draft:
   description: incl. anti-deobfuscation techniques

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0092.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0092.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [R]
 mappings:
   masvs-v2: [MASVS-RESILIENCE-3]
+  cwe: [657]
 
 draft:
   description: AKA static damage control

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0093.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0093.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-CODE-3]
   masvs-v2: [MASVS-RESILIENCE-3]
+  cwe: [657]
 
 draft:
   description: nm or objdump reveal symbols

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0094.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0094.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-CODE-4]
   masvs-v2: [MASVS-RESILIENCE-3]
+  cwe: [540]
 
 draft:
   description: e.g. non-production URLs, code flows, verbose logging

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0095.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0095.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-CODE-4]
   masvs-v2: [MASVS-RESILIENCE-3]
+  cwe: [489, 912]
 
 draft:
   description: backdoors, hidden settings to e.g. disable TLS verification

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0096.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0096.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-13]
   masvs-v2: [MASVS-RESILIENCE-3, MASVS-NETWORK-1]
+  cwe: [319]
 
 draft:
   description: Use payload/End-2-End Encryption. Even if the connection is encrypted

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0097.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0097.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-1]
   masvs-v2: [MASVS-RESILIENCE-1]
+  cwe: [250, 358]
 
 draft:
   description: no root/jailbreak detection implemented e.g. check for Cydia, SuperSU,

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0098.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0098.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [R]
 mappings:
   masvs-v2: [MASVS-RESILIENCE-1]
+  cwe: [358]
 
 draft:
   description: runs as a so-called "clone app"

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0099.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0099.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-5]
   masvs-v2: [MASVS-RESILIENCE-1]
+  cwe: [358]
 
 draft:
   description: e.g. identifying features and limitations available for commonly used

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0100.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0100.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-10]
   masvs-v2: [MASVS-RESILIENCE-1]
+  cwe: [353]
 
 refs:
 - https://developer.android.com/google/play/integrity

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0101.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0101.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-2]
   masvs-v2: [MASVS-RESILIENCE-4]
+  cwe: [693]
 
 draft:
   description: implementing techniques to detect debuggers

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0102.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0102.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-4]
   masvs-v2: [MASVS-RESILIENCE-4]
+  cwe: [693]
 
 draft:
   description: e.g. Frida, Xposed, Cydia Substrate, etc.

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0103.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0103.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-8]
   masvs-v2: [MASVS-RESILIENCE-4]
+  cwe: [693]
 
 draft:
   description: e.g. Runtime Application Self-Protection, detection triggering different

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0104.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0104.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-CODE-1]
   masvs-v2: [MASVS-RESILIENCE-2]
+  cwe: [353]
 
 refs:
 - https://developer.apple.com/documentation/xcode/using-the-latest-code-signature-format

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0105.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0105.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-3]
   masvs-v2: [MASVS-RESILIENCE-2, MASVS-CODE-4]
+  cwe: [353]
 
 draft:
   description: e.g. integrity of downloaded resources or dynamically loaded resources

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0106.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0106.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [R]
 mappings:
   masvs-v2: [MASVS-RESILIENCE-2]
+  cwe: [353]
 
 draft:
   description: Google PlayStore or Apple AppStore

--- a/weaknesses/MASVS-RESILIENCE/MASWE-0107.md
+++ b/weaknesses/MASVS-RESILIENCE/MASWE-0107.md
@@ -7,6 +7,7 @@ profiles: [R]
 mappings:
   masvs-v1: [MSTG-RESILIENCE-6]
   masvs-v2: [MASVS-RESILIENCE-2]
+  cwe: [114]
 
 draft:
   description: e.g. memory tampering detection


### PR DESCRIPTION
- Update all CWE IDs on MASWE elements of MASVS-RESILIENCE
- On MASWE-0094 consider that **if** software logic can be idetified as "sensitive information", the verbose logging control is already in scope in MASWE-0001

This PR is related to issue #2858 .