### PR TITLE
Update CWE mapping on MASWE elements of MASVS-CODE

### DIFF
--- a/weaknesses/MASVS-CODE/MASWE-0075.md
+++ b/weaknesses/MASVS-CODE/MASWE-0075.md
@@ -7,6 +7,7 @@ profiles: [L2]
 mappings:
   masvs-v1: [MSTG-ARCH-9]
   masvs-v2: [MASVS-CODE-2]
+  cwe: [357]
 
 refs:
 - https://developer.android.com/guide/playcore/in-app-updates

--- a/weaknesses/MASVS-CODE/MASWE-0076.md
+++ b/weaknesses/MASVS-CODE/MASWE-0076.md
@@ -7,6 +7,7 @@ profiles: [L1, L2]
 mappings:
   masvs-v1: [MSTG-CODE-5]
   masvs-v2: [MASVS-CODE-3]
+  cwe: [1395]
 
 draft:
   description: e.g. via dependency check and SBOM (software bill of materials)

--- a/weaknesses/MASVS-CODE/MASWE-0077.md
+++ b/weaknesses/MASVS-CODE/MASWE-0077.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L2]
 mappings:
   masvs-v2: [MASVS-CODE-1]
+  cwe: [693]
 
 draft:
   description: e.g. via minSdkVersion on Android and MinimumOSVersion on iOS. with

--- a/weaknesses/MASVS-CODE/MASWE-0078.md
+++ b/weaknesses/MASVS-CODE/MASWE-0078.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L2]
 mappings:
   masvs-v2: [MASVS-CODE-1]
+  cwe: [1188]
 
 draft:
   description: e.g. via targetSDK on Android The app should be targeting the latest

--- a/weaknesses/MASVS-CODE/MASWE-0079.md
+++ b/weaknesses/MASVS-CODE/MASWE-0079.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L1, L2]
 mappings:
   masvs-v2: [MASVS-CODE-4]
+  cwe: [924]
 
 draft:
   description: Data received from the network should be treated as untrusted even

--- a/weaknesses/MASVS-CODE/MASWE-0080.md
+++ b/weaknesses/MASVS-CODE/MASWE-0080.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L1, L2]
 mappings:
   masvs-v2: [MASVS-CODE-4]
+  cwe: [349]
 
 refs:
 - https://developer.android.com/guide/topics/data/keyvaluebackup#RestoreVersion

--- a/weaknesses/MASVS-CODE/MASWE-0081.md
+++ b/weaknesses/MASVS-CODE/MASWE-0081.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L1, L2]
 mappings:
   masvs-v2: [MASVS-CODE-4]
+  cwe: [924]
 
 draft:
   description: When data is received from external interfaces (e.g. Bluetooth, NFC,

--- a/weaknesses/MASVS-CODE/MASWE-0082.md
+++ b/weaknesses/MASVS-CODE/MASWE-0082.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L1, L2]
 mappings:
   masvs-v2: [MASVS-CODE-4]
+  cwe: [349, 22]
 
 refs:
 - https://developer.android.com/topic/security/risks/path-traversal

--- a/weaknesses/MASVS-CODE/MASWE-0083.md
+++ b/weaknesses/MASVS-CODE/MASWE-0083.md
@@ -7,6 +7,7 @@ profiles: [L1, L2]
 mappings:
   masvs-v1: [MSTG-PLATFORM-2]
   masvs-v2: [MASVS-CODE-4, MASVS-PLATFORM-3]
+  cwe: [345, 348]
 
 draft:
   description: e.g. text fields, QR codes, URLs, pasteboard, etc.

--- a/weaknesses/MASVS-CODE/MASWE-0084.md
+++ b/weaknesses/MASVS-CODE/MASWE-0084.md
@@ -7,6 +7,7 @@ profiles: [L1, L2]
 mappings:
   masvs-v1: [MSTG-PLATFORM-2]
   masvs-v2: [MASVS-CODE-4, MASVS-PLATFORM-1]
+  cwe: [345, 349]
 
 draft:
   description: e.g. received intents, broadcast receivers, URL validation, URL schemes,

--- a/weaknesses/MASVS-CODE/MASWE-0085.md
+++ b/weaknesses/MASVS-CODE/MASWE-0085.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L2]
 mappings:
   masvs-v2: [MASVS-CODE-4]
+  cwe: [494]
 
 draft:
   description: e.g. when using dlopen, DexClassLoader, etc.

--- a/weaknesses/MASVS-CODE/MASWE-0086.md
+++ b/weaknesses/MASVS-CODE/MASWE-0086.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L1, L2]
 mappings:
   masvs-v2: [MASVS-CODE-4]
+  cwe: [89]
 
 refs:
 - https://developer.android.com/topic/security/risks/sql-injection

--- a/weaknesses/MASVS-CODE/MASWE-0087.md
+++ b/weaknesses/MASVS-CODE/MASWE-0087.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L2]
 mappings:
   masvs-v2: [MASVS-CODE-4]
+  cwe: [116, 347, 611]
 
 draft:
   description: e.g. XML External Entity (XXE) attacks, X509 certificate parsing, character

--- a/weaknesses/MASVS-CODE/MASWE-0088.md
+++ b/weaknesses/MASVS-CODE/MASWE-0088.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L2]
 mappings:
   masvs-v2: [MASVS-CODE-4]
+  cwe: [502]
 
 draft:
   description: e.g. XML, JSON, java.io.Serializable, Parcelable on Android or NSCoding

--- a/weaknesses/MASVS-CODE/MASWE-0116.md
+++ b/weaknesses/MASVS-CODE/MASWE-0116.md
@@ -6,6 +6,7 @@ platform: [android, ios]
 profiles: [L2]
 mappings:
   masvs-v2: [MASVS-CODE-3, MASVS-CODE-4]
+  cwe: [119]
 refs:
 - https://cs.android.com/android/platform/superproject/main/+/main:bionic/linker/linker_main.cpp;l=397?q=linker_main&ss=android%2Fplatform%2Fsuperproject%2Fmain
 - https://partners.trellix.com/enterprise/en-us/assets/white-papers/wp-secure-coding-android-applications.pdf


### PR DESCRIPTION
- Update all CWE IDs on MASWE elements of MASVS-CODE
- On MASWE-0116 consider changing the name in "Memory Protection Not Enabled During Build"
- MASWE-0083 may be split in two, managing differently the weakness between user-managed input (text from keyboard, related to CWE-345) and hardware or system-managed input (QR, URL, clipboard, related to CWE-348)

This PR is related to issue #2858 .