### PR TITLE
build-android-demos.yml: simplify shell scripts and cache Android app build

### DIFF
--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -37,7 +37,7 @@ jobs:
   build:
     needs: generate-matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 60  # Increase this value as needed
+    timeout-minutes: 30  # Increase this value as needed
     strategy:
       matrix: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
       max-parallel: 3  # Limit the number of parallel jobs
@@ -48,17 +48,36 @@ jobs:
         with:
           sparse-checkout: demos/android
 
-      - name: Clone MASTestApp-Android repository
-        uses: actions/checkout@v4
-        with:
-          repository: cpholguera/MASTestApp-Android
-          path: MASTestApp-Android
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: false
+
+      - name: Get last commit hash of MASTestApp-Android
+        id: get-mastestapp-hash
+        run: echo "mastestapp_hash=$(git ls-remote https://github.com/cpholguera/MASTestApp-Android.git HEAD | awk '{print $1}')" >> $GITHUB_ENV 
+
+      - name: Restore cache
+        id: cache-base-app
+        uses: actions/cache/restore@v4
+        with:
+          path: MASTestApp-Android/
+          key: build-${{ env.mastestapp_hash }}
+
+      - name: Clone MASTestApp-Android repository
+        if: steps.cache-base-app.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: cpholguera/MASTestApp-Android
+          path: MASTestApp-Android
+          ref: ${{ env.mastestapp_hash }}
 
       - name: Replace files and build APK
         run: |
@@ -93,6 +112,13 @@ jobs:
           )
           echo "APK for $demo moved to $apk_filename"
           echo "APK_NAME=$apk_filename" >> $GITHUB_ENV
+
+      - name: Saving cache
+        uses: actions/cache/save@v4
+        if: steps.cache-base-app.outputs.cache-hit != 'true'
+        with:
+          path: MASTestApp-Android/
+          key: ${{ steps.cache-base-app.outputs.cache-primary-key }}
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -28,14 +28,8 @@ jobs:
       - name: Generate matrix
         id: set-matrix
         run: |
-          demos=$(find demos/android -type d -name "MASTG-DEMO-*")
-          matrix="{\"demo\":["
-          for demo in $demos; do
-            matrix="${matrix}\"$demo\","
-          done
-          matrix="${matrix%,}]}"
-          echo "matrix=$matrix" >> $GITHUB_ENV
-          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+          matrix="$(echo demos/android/*/MASTG-DEMO-* | sed 's/ /","/g')"
+          echo "matrix={\"demo\":[\"$matrix\"]}" >> $GITHUB_OUTPUT
 
       - name: Print matrix
         run: echo "${{ steps.set-matrix.outputs.matrix }}"

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -12,6 +12,7 @@ on:
       - master
     paths:
       - 'demos/**'
+      - '.github/workflows/build-android-demos.yml'
 
 jobs:
   generate-matrix:
@@ -21,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: demos/android
 
       - name: Generate matrix
         id: set-matrix
@@ -48,6 +51,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          sparse-checkout: demos/android
 
       - name: Clone MASTestApp-Android repository
         run: git clone https://github.com/cpholguera/MASTestApp-Android.git

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -60,30 +60,34 @@ jobs:
       - name: Replace files and build APK
         run: |
           demo="${{ matrix.demo }}"
-          if [ -d "$demo" ]; then
-            echo "Processing $demo"
-            [ -f "$demo/MastgTest.kt" ] && cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt && echo "Copied MastgTest.kt for $demo" || echo "No MastgTest.kt found for $demo"
-            [ -f "$demo/AndroidManifest.xml" ] && cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml && echo "Copied AndroidManifest.xml for $demo" || echo "No AndroidManifest.xml found for $demo"
-            cd MASTestApp-Android
-            echo "Building APK for $demo"
-            ./gradlew assembleDebug --stacktrace
-            build_status=$?
-            cd ..
-            if [ $build_status -eq 0 ]; then
-              echo "Build succeeded for $demo"
-              apk_name="$(basename "$demo").apk"
-              if [ -f "MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk" ]; then
-                mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$apk_name"
-                echo "APK for $demo moved to $apk_name"
-              else
-                echo "APK not found for $demo"
-              fi
-            else
-              echo "Build failed for $demo"
-            fi
-          else
+          [ -d "$demo" ] || (
             echo "Demo directory not found: $demo"
-          fi
+            exit 1
+          )
+
+          echo "Processing $demo"
+          cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt 2>/dev/null \
+            && echo "Copied MastgTest.kt for $demo" \
+            || echo "No MastgTest.kt found for $demo"
+          cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml 2>/dev/null \
+            && echo "Copied AndroidManifest.xml for $demo" \
+            || echo "No AndroidManifest.xml found for $demo"
+          
+          echo "Building APK for $demo"
+          cd MASTestApp-Android
+          grep -q 'org.gradle.caching=true' gradle.properties || echo -en "\norg.gradle.caching=true\norg.gradle.configuration-cache=true\n" >> gradle.properties
+          ./gradlew assembleDebug --stacktrace || (
+            echo "Build failed for $demo"
+            exit 1
+          )
+          cd ..
+          echo "Build succeeded for $demo"          
+
+          apk_filename="$(basename "$demo").apk"
+          mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$apk_filename" || (
+            echo "APK not found for $demo"
+            exit 1
+          )
 
       - name: Set APK name variable
         id: set_apk_name

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -49,7 +49,10 @@ jobs:
           sparse-checkout: demos/android
 
       - name: Clone MASTestApp-Android repository
-        run: git clone https://github.com/cpholguera/MASTestApp-Android.git
+        uses: actions/checkout@v4
+        with:
+          repository: cpholguera/MASTestApp-Android
+          path: MASTestApp-Android
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -52,7 +52,7 @@ jobs:
         run: git clone https://github.com/cpholguera/MASTestApp-Android.git
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -88,15 +88,8 @@ jobs:
             echo "APK not found for $demo"
             exit 1
           )
-
-      - name: Set APK name variable
-        id: set_apk_name
-        run: echo "APK_NAME=$(basename ${{ matrix.demo }}).apk" >> $GITHUB_ENV
-
-      - name: List generated APK
-        run: |
-          echo "Listing generated APK in demos/android directory:"
-          ls -l "${{ env.APK_NAME }}" || echo "No APK found."
+          echo "APK for $demo moved to $apk_filename"
+          echo "APK_NAME=$apk_filename" >> $GITHUB_ENV
 
       - name: Upload APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- simplify shell scripts.
- caches the MASTestApp-Android App in order to speed up the app demo builds.
- reduces build time from 18 min to <5 min.

This PR closes #3156.
