### PR TITLE
Use ./gradlew assembleRelease to decrease the Android demo APK size

### DIFF
--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -150,7 +150,7 @@ jobs:
           echo "Build succeeded for $demo"          
 
           apk_filename="$(basename "$demo").apk"
-          mv MASTestApp-Android/app/build/outputs/apk/debug/app-debug.apk "$apk_filename" || (
+          mv MASTestApp-Android/app/build/outputs/apk/release/*.apk "$apk_filename" || (
             echo "APK not found for $demo"
             exit 1
           )

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           lookup-only: true
           path: MASTestApp-Android/ # we're forced to write a path even if we don't need it
-          key: base-app-${{ env.MASTESTAPP_HASH }}
+          key: base-app-${{ env.MASTESTAPP_HASH }}-${{ hashFiles('.github/workflows/build-android-demos.yml') }}
 
       - name: Set up JDK 17
         if: steps.cache-check.outputs.cache-hit != 'true'
@@ -78,7 +78,7 @@ jobs:
         run: |
           cd MASTestApp-Android
           grep -q 'org.gradle.caching=true' gradle.properties || echo -en "\norg.gradle.caching=true\norg.gradle.configuration-cache=true\n" >> gradle.properties
-          ./gradlew assembleDebug --stacktrace || (
+          ./gradlew assembleRelease --stacktrace || (
             echo "Build failed"
             exit 1
           )
@@ -142,7 +142,7 @@ jobs:
           echo "Building APK for $demo"
           cd MASTestApp-Android
           grep -q 'org.gradle.caching=true' gradle.properties || echo -en "\norg.gradle.caching=true\norg.gradle.configuration-cache=true\n" >> gradle.properties
-          ./gradlew assembleDebug --stacktrace || (
+          ./gradlew assembleRelease --stacktrace || (
             echo "Build failed for $demo"
             exit 1
           )


### PR DESCRIPTION
assembleRelease seems to decrease the APK size, but it also increases build time:

- 3m 21s  -> 5m 10s
- 24,9 -> 18,7MB 

@cpholguera What do you prefer, smaller APK size or lower build time?

![image](https://github.com/user-attachments/assets/0be1150f-5e0b-4431-a4a0-10d9473a72f6)

This PR closes #3159 
