### PR TITLE
MASTG v1->v2 MASTG-TEST-0061 Verifying the Configuration of Cryptographic Standard Algorithms (ios) and MASTG-TEST-0062 Testing Key Management (ios)

### DIFF
--- a/tests/ios/MASVS-CRYPTO/MASTG-TEST-0061.md
+++ b/tests/ios/MASVS-CRYPTO/MASTG-TEST-0061.md
@@ -9,6 +9,9 @@ title: Verifying the Configuration of Cryptographic Standard Algorithms
 masvs_v1_levels:
 - L1
 - L2
+status: deprecated
+covered_by: [MASTG-TEST-0209, MASTG-TEST-0210, MASTG-TEST-0211]
+deprecation_note: New version available in MASTG V2
 ---
 
 ## Overview

--- a/tests/ios/MASVS-CRYPTO/MASTG-TEST-0062.md
+++ b/tests/ios/MASVS-CRYPTO/MASTG-TEST-0062.md
@@ -9,6 +9,9 @@ title: Testing Key Management
 masvs_v1_levels:
 - L1
 - L2
+status: deprecated
+covered_by: [MASTG-TEST-0213, MASTG-TEST-0214]
+deprecation_note: New version available in MASTG V2
 ---
 
 ## Overview


### PR DESCRIPTION
- MASTG-TEST-0209 MASTG-TEST-0210 will cover MASTG-TEST-0061 in v2
- MASTG-TEST-0213, MASTG-TEST-0214 will cover MASTG-TEST-0062 in v2

This PR closes #2945 closes #2943
