### PR TITLE
Only run APK/IPA builds on changes demos in PRs only

### DIFF
--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -37,7 +37,7 @@ jobs:
             echo "$changed_files"
 
             # Extract unique demo directories
-            matrix=$(echo "$changed_files" | grep -oE 'demos/android/[^/]+' | sort -u | sed 's/ /","/g')
+            matrix=$(echo "$changed_files" | grep -oE 'demos/android/[^/]*/MASTG-DEMO-[^/]+' | sort -u | sed 's/ /","/g')
 
             # If no changes, set empty matrix
             if [ -z "$matrix" ]; then

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -33,6 +33,9 @@ jobs:
             # Get list of changed files in demos/android/ directory
             changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD -- 'demos/android/*')
 
+            echo "Changed files:"
+            echo "$changed_files"
+
             # Extract unique demo directories
             matrix=$(echo "$changed_files" | grep -oE 'demos/android/[^/]+' | sort -u | sed 's/ /","/g')
 

--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -24,12 +24,29 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: demos/android
+          fetch-depth: 2 # Required for git diff in PRs
 
       - name: Generate matrix
         id: set-matrix
         run: |
-          matrix="$(echo demos/android/*/MASTG-DEMO-* | sed 's/ /","/g')"
-          echo "matrix={\"demo\":[\"$matrix\"]}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Get list of changed files in demos/android/ directory
+            changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD -- 'demos/android/*')
+
+            # Extract unique demo directories
+            matrix=$(echo "$changed_files" | grep -oE 'demos/android/[^/]+' | sort -u | sed 's/ /","/g')
+
+            # If no changes, set empty matrix
+            if [ -z "$matrix" ]; then
+              echo "matrix={\"demo\":[]}" >> $GITHUB_OUTPUT
+            else
+              echo "matrix={\"demo\":[\"$matrix\"]}" >> $GITHUB_OUTPUT
+            fi
+          else
+            # Default behavior: include all demos for master branch
+            matrix=$(echo demos/android/*/MASTG-DEMO-* | sed 's/ /","/g')
+            echo "matrix={\"demo\":[\"$matrix\"]}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Print matrix
         run: echo "${{ steps.set-matrix.outputs.matrix }}"

--- a/.github/workflows/build-ios-demos.yml
+++ b/.github/workflows/build-ios-demos.yml
@@ -36,7 +36,7 @@ jobs:
             echo "$changed_files"
 
             # Extract unique demo directories
-            matrix=$(echo "$changed_files" | grep -oE 'demos/ios/[^/]+' | sort -u | sed 's/ /","/g')
+            matrix=$(echo "$changed_files" | grep -oE 'demos/ios/[^/]*/MASTG-DEMO-[^/]+' | sort -u | sed 's/ /","/g')
 
             # If no changes, set empty matrix
             if [ -z "$matrix" ]; then

--- a/.github/workflows/build-ios-demos.yml
+++ b/.github/workflows/build-ios-demos.yml
@@ -32,6 +32,9 @@ jobs:
             # Get list of changed files in demos/ios/ directory
             changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD -- 'demos/ios/*')
 
+            echo "Changed files:"
+            echo "$changed_files"
+
             # Extract unique demo directories
             matrix=$(echo "$changed_files" | grep -oE 'demos/ios/[^/]+' | sort -u | sed 's/ /","/g')
 

--- a/.github/workflows/build-ios-demos.yml
+++ b/.github/workflows/build-ios-demos.yml
@@ -23,12 +23,29 @@ jobs:
         uses: actions/checkout@v4
         with:
           sparse-checkout: demos/ios
+          fetch-depth: 2 # Required for git diff in PRs
 
       - name: Generate matrix
         id: set-matrix
         run: |
-          matrix="$(echo demos/ios/*/MASTG-DEMO-* | sed 's/ /","/g')"
-          echo "matrix={\"demo\":[\"$matrix\"]}" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Get list of changed files in demos/ios/ directory
+            changed_files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} HEAD -- 'demos/ios/*')
+
+            # Extract unique demo directories
+            matrix=$(echo "$changed_files" | grep -oE 'demos/ios/[^/]+' | sort -u | sed 's/ /","/g')
+
+            # If no changes, set empty matrix
+            if [ -z "$matrix" ]; then
+              echo "matrix={\"demo\":[]}" >> $GITHUB_OUTPUT
+            else
+              echo "matrix={\"demo\":[\"$matrix\"]}" >> $GITHUB_OUTPUT
+            fi
+          else
+            # Default behavior: include all demos for master branch
+            matrix=$(echo demos/ios/*/MASTG-DEMO-* | sed 's/ /","/g')
+            echo "matrix={\"demo\":[\"$matrix\"]}" >> $GITHUB_OUTPUT
+          fi
 
   build:
     needs: generate-matrix

--- a/demos/android/MASVS-CODE/MASTG-DEMO-0025/MASTG-DEMO-0025.md
+++ b/demos/android/MASVS-CODE/MASTG-DEMO-0025/MASTG-DEMO-0025.md
@@ -8,7 +8,7 @@ test: MASTG-TEST-0245
 
 ### Sample
 
-The following example checks the version of the operating system.
+The following sample uses the `Build.VERSION.SDK_INT` API to check the operating system version.
 
 {{ MastgTest.kt # MastgTest_reversed.java }}
 

--- a/demos/ios/MASVS-CRYPTO/MASTG-DEMO-0011/MASTG-DEMO-0011.md
+++ b/demos/ios/MASVS-CRYPTO/MASTG-DEMO-0011/MASTG-DEMO-0011.md
@@ -8,6 +8,8 @@ test: MASTG-TEST-0209
 
 ### Sample
 
+The following sample demonstrates the use of `SecKeyCreateRandomKey` to generate an RSA key pair with a 1024-bit key size. The key pair is then used to sign and verify a message.
+
 {{ MastgTest.swift }}
 
 ### Steps

--- a/docs/hooks/github_api.py
+++ b/docs/hooks/github_api.py
@@ -14,13 +14,14 @@ HEADERS = {
     "Accept": "application/vnd.github+json",
 }
 
-def get_latest_successful_run(workflow_file):
+def get_latest_successful_run(workflow_file, branch="master"):
     url = f"https://api.github.com/repos/{GITHUB_REPO}/actions/workflows/{workflow_file}/runs"
-    params = {"status": "success", "per_page": 1}
+    params = {"status": "success", "branch": branch, "per_page": 1}
     response = requests.get(url, headers=HEADERS, params=params)
     response.raise_for_status()
-    runs = response.json()["workflow_runs"]
+    runs = response.json().get("workflow_runs", [])
+    
     if runs:
-        return f"{runs[0]["html_url"]}#artifacts"
+        return f"{runs[0]['html_url']}#artifacts"
     else:
         return None


### PR DESCRIPTION
This PR closes #3204 

This PR optimizes the GitHub Action for building Android and iOS demos by modifying its behavior based on the event type:

- For push to master: The workflow remains unchanged and builds all Android demos.
- For pull requests: The build now runs only if files within `demos/android/**` or `demos/ios/**` have changed, reducing unnecessary builds. This is achieved by using `git diff` to detect modified files and updating the matrix accordingly.

This improves CI efficiency by avoiding redundant builds when no relevant changes are made.


**Additional changes: Demo download buttons**

This PR also updated the script that ensures that the last successful run of the GitHub Action was on the master branch. 

- Script: `docs/hooks/github_api.py`
- Used from: `docs/hooks/maswe-beta-banner.py` in the `get_android_demo_buttons` and `get_android_demo_buttons` methods.

Previously, the script fetched the most recent successful run without checking the branch, which could lead to using artifacts from non-master branches. Now, it explicitly filters for successful runs on master, ensuring that only stable and merged builds are considered.
