### PR TITLE
Add draft demos for detecting local file access in WebViews

### DIFF
--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0031/MASTG-DEMO-0031.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0031/MASTG-DEMO-0031.md
@@ -1,0 +1,9 @@
+---
+platform: android
+title: Uses of WebViews Allowing Local File Access with Frida
+id: MASTG-DEMO-0031
+code: [kotlin]
+test: MASTG-TEST-0253
+status: draft
+note: This demo shows how to use Frida to detect the use of WebView settings that allow local file access in an Android app.
+---

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0032/MASTG-DEMO-0032.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0032/MASTG-DEMO-0032.md
@@ -1,0 +1,9 @@
+---
+platform: android
+title: Uses of WebViews Allowing Local File Access with semgrep
+id: MASTG-DEMO-0032
+code: [kotlin]
+test: MASTG-TEST-0252
+status: draft
+note: This demo shows how to use semgrep to detect the use of WebView settings that allow local file access in an Android app.
+---


### PR DESCRIPTION
Introduce draft demos utilizing Frida and semgrep to identify WebView settings that permit local file access in Android applications.