### PR TITLE
Fix Android demo build workflow by explicitly copying individual files

### DIFF
--- a/.github/workflows/build-android-demos.yml
+++ b/.github/workflows/build-android-demos.yml
@@ -152,11 +152,27 @@ jobs:
           )
 
           echo "Processing $demo"
-          for file in MastgTest.kt AndroidManifest.xml filepaths.xml network_security_config.xml backup_rules.xml data_extraction_rules.xml; do
-          cp -f "$demo/$file" "MASTestApp-Android/app/src/main/${file%/*}/$file" 2>/dev/null \
-            && echo "Copied $file for $demo" \
-            || echo "No $file found for $demo"
-          done
+          cp -f "$demo/MastgTest.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTest.kt 2>/dev/null \
+            && echo "Copied MastgTest.kt for $demo" \
+            || echo "No MastgTest.kt found for $demo"
+          cp -f "$demo/MastgTestWebView.kt" MASTestApp-Android/app/src/main/java/org/owasp/mastestapp/MastgTestWebView.kt 2>/dev/null \
+            && echo "Copied MastgTestWebView.kt for $demo" \
+            || echo "No MastgTestWebView.kt found for $demo"
+          cp -f "$demo/AndroidManifest.xml" MASTestApp-Android/app/src/main/AndroidManifest.xml 2>/dev/null \
+            && echo "Copied AndroidManifest.xml for $demo" \
+            || echo "No AndroidManifest.xml found for $demo"
+          cp -f "$demo/filepaths.xml" MASTestApp-Android/app/src/main/res/xml/filepaths.xml 2>/dev/null \
+            && echo "Copied filepaths.xml for $demo" \
+            || echo "No filepaths.xml found for $demo"
+          cp -f "$demo/network_security_config.xml" MASTestApp-Android/app/src/main/res/xml/network_security_config.xml 2>/dev/null \
+            && echo "Copied network_security_config.xml for $demo" \
+            || echo "No network_security_config.xml found for $demo"
+          cp -f "$demo/backup_rules.xml" MASTestApp-Android/app/src/main/res/xml/backup_rules.xml 2>/dev/null \
+            && echo "Copied backup_rules.xml for $demo" \
+            || echo "No backup_rules.xml found for $demo"
+          cp -f "$demo/data_extraction_rules.xml" MASTestApp-Android/app/src/main/res/xml/data_extraction_rules.xml 2>/dev/null \
+            && echo "Copied data_extraction_rules.xml for $demo" \
+            || echo "No data_extraction_rules.xml found for $demo"
           
           echo "Building APK for $demo"
           cd MASTestApp-Android


### PR DESCRIPTION
Update the build workflow to explicitly copy each required file for the Android demo, ensuring all necessary files are included for a successful build.