### PR TITLE
Update MASWE-0052.md (fix missing coma in cwes)

### DIFF
--- a/weaknesses/MASVS-NETWORK/MASWE-0052.md
+++ b/weaknesses/MASVS-NETWORK/MASWE-0052.md
@@ -7,7 +7,7 @@ profiles: [L1, L2]
 mappings:
   masvs-v1: [MSTG-NETWORK-3]
   masvs-v2: [MASVS-NETWORK-1]
-  cwe: [295. 297]
+  cwe: [295, 297]
   android-risks:
   - https://developer.android.com/privacy-and-security/risks/unsafe-trustmanager
   - https://developer.android.com/privacy-and-security/risks/unsafe-hostname


### PR DESCRIPTION
Corrected a typo in the `cwe` mappings of `weaknesses/MASVS-NETWORK/MASWE-0052.md` by replacing a period with a comma.
