### PR TITLE
Fix duplicate ID checker to handle PRs with no existing comments

### DIFF
--- a/.github/workflows/check-duplicate-ids.yml
+++ b/.github/workflows/check-duplicate-ids.yml
@@ -142,7 +142,7 @@ jobs:
               } catch (error) {
                 console.log(`Error posting review comment: ${error.message}`);
                 
-                // Fallback: post a regular issue comment
+                // Fallback: post a comment on the PR thread instead of as a review comment
                 try {
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
@@ -150,9 +150,9 @@ jobs:
                     issue_number: context.issue.number,
                     body: formatDuplicateMessage(duplicate, false)
                   });
-                  console.log(`Posted fallback issue comment for ${duplicate.file_path}`);
+                  console.log(`Posted fallback PR thread comment for ${duplicate.file_path}`);
                 } catch (fallbackError) {
-                  console.log(`Error posting fallback comment: ${fallbackError.message}`);
+                  console.log(`Error posting fallback PR thread comment: ${fallbackError.message}`);
                 }
               }
             }

--- a/.github/workflows/check-duplicate-ids.yml
+++ b/.github/workflows/check-duplicate-ids.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           python .github/scripts/check_duplicate_ids.py
           
-      - name: Handle duplicate ID notifications
+      - name: Delete previous comments and comment on PR if duplicates found
         if: always()
         uses: actions/github-script@v6
         with:

--- a/.github/workflows/check-duplicate-ids.yml
+++ b/.github/workflows/check-duplicate-ids.yml
@@ -50,57 +50,16 @@ jobs:
         run: |
           python .github/scripts/check_duplicate_ids.py
           
-      - name: Delete previous comments and comment on PR if duplicates found
+      - name: Handle duplicate ID notifications
         if: always()
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // Get all review comments on the PR
-            const comments = await github.rest.pulls.listReviewComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            
-            // Filter for comments that are likely from this action
-            // The identifier is the header "### ⚠️ Duplicate" which is unique to our action
-            const ourComments = comments.data.filter(comment => 
-              comment.body.includes('### ⚠️ Duplicate') && 
-              comment.body.includes('ID Detected')
-            );
-            
-            console.log(`Found ${ourComments.length} previous comments from this action.`);
-            
-            // Delete the comments
-            for (const comment of ourComments) {
-              console.log(`Deleting comment ID ${comment.id}`);
-              await github.rest.pulls.deleteReviewComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: comment.id
-              });
-            }
-            
-            // Check if we have new duplicates to report
-            const hasDuplicatesOutput = '${{ steps.check-duplicates.outputs.has_duplicates }}';
-            
-            if (hasDuplicatesOutput !== 'true') {
-              console.log('No duplicates found, no new comments to post.');
-              return;
-            }
-            
-            // Check if the duplicates file exists before trying to read it
             const fs = require('fs');
-            if (!fs.existsSync('duplicate_files.json')) {
-              console.log('No duplicate_files.json found.');
-              return;
-            }
             
-            const duplicatesData = JSON.parse(fs.readFileSync('duplicate_files.json', 'utf8'));
-            
-            // Add new comments for any duplicates
-            for (const duplicate of duplicatesData) {
+            // Helper function to format a notification message
+            const formatDuplicateMessage = (duplicate, isReviewComment = true) => {
               // Extract the ID prefix for a more specific message
               let idType = duplicate.file_id.split('-').slice(0, 2).join('-');
               
@@ -109,22 +68,91 @@ jobs:
                 idType = 'MASWE';
               }
               
-              const message = `
-              ### ⚠️ Duplicate \`${idType}\` ID Detected
+              // Choose the appropriate header style based on comment type
+              const headerPrefix = isReviewComment ? '###' : '##';
               
-              This file has the ID \`${duplicate.file_id}\` which already exists in \`${duplicate.existing_path}\`.
+              return `
+              ${headerPrefix} ⚠️ Duplicate \`${idType}\` ID Detected
+              
+              ${isReviewComment ? 'This file' : `File \`${duplicate.file_path}\``} has the ID \`${duplicate.file_id}\` which already exists in \`${duplicate.existing_path}\`.
               
               **IMPORTANT:** Please use the next available ID: \`${duplicate.suggested_id}\`
               `;
-              
-              await github.rest.pulls.createReviewComment({
+            };
+            
+            // Step 1: Try to clean up existing comments
+            try {
+              const comments = await github.rest.pulls.listReviewComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                pull_number: context.issue.number,
-                commit_id: context.payload.pull_request.head.sha,
-                path: duplicate.file_path,
-                body: message,
-                line: 1,
-                side: 'RIGHT'
+                pull_number: context.issue.number
               });
+              
+              // Filter for comments from this action
+              const ourComments = comments.data.filter(comment => 
+                comment.body.includes('⚠️ Duplicate') && 
+                comment.body.includes('ID Detected')
+              );
+              
+              console.log(`Found ${ourComments.length} previous comments from this action.`);
+              
+              // Delete the comments
+              for (const comment of ourComments) {
+                try {
+                  await github.rest.pulls.deleteReviewComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: comment.id
+                  });
+                  console.log(`Deleted comment ID ${comment.id}`);
+                } catch (error) {
+                  console.log(`Error deleting comment ID ${comment.id}: ${error.message}`);
+                }
+              }
+            } catch (error) {
+              console.log(`Error handling existing comments: ${error.message}`);
+              // Continue with the workflow regardless of errors with existing comments
+            }
+            
+            // Step 2: Check if we need to post new notifications
+            const hasDuplicatesOutput = '${{ steps.check-duplicates.outputs.has_duplicates }}';
+            
+            if (hasDuplicatesOutput !== 'true' || !fs.existsSync('duplicate_files.json')) {
+              console.log('No duplicates to report.');
+              return;
+            }
+            
+            // Step 3: Post notifications for each duplicate
+            const duplicatesData = JSON.parse(fs.readFileSync('duplicate_files.json', 'utf8'));
+            
+            for (const duplicate of duplicatesData) {
+              // First try posting a review comment (preferred method)
+              try {
+                await github.rest.pulls.createReviewComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number,
+                  commit_id: context.payload.pull_request.head.sha,
+                  path: duplicate.file_path,
+                  body: formatDuplicateMessage(duplicate, true),
+                  line: 1,
+                  side: 'RIGHT'
+                });
+                console.log(`Successfully posted review comment for ${duplicate.file_path}`);
+              } catch (error) {
+                console.log(`Error posting review comment: ${error.message}`);
+                
+                // Fallback: post a regular issue comment
+                try {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    body: formatDuplicateMessage(duplicate, false)
+                  });
+                  console.log(`Posted fallback issue comment for ${duplicate.file_path}`);
+                } catch (fallbackError) {
+                  console.log(`Error posting fallback comment: ${fallbackError.message}`);
+                }
+              }
             }


### PR DESCRIPTION
Fix duplicate ID checker GitHub Action to handle PRs with no comments in `.github/workflows/check-duplicate-ids.yml`.

Issue: the workflow failed when running on PRs without any existing review comments.

Key fixes:

- Added proper error handling around comment operations
- Created a helper function to generate consistent notification messages
- Added a fallback to issue comments when review comments can't be created
- Simplified the workflow and added more comments