### PR TITLE
Add new drafts for privacy test cases in Android

### DIFF
--- a/tests-beta/android/MASVS-PRIVACY/MASTG-TEST-0255.md
+++ b/tests-beta/android/MASVS-PRIVACY/MASTG-TEST-0255.md
@@ -1,0 +1,8 @@
+---
+platform: android
+title: Permission Requests Not Minimized
+id: MASTG-TEST-0255
+weakness: MASWE-0117
+status: draft
+note: This test checks if the app requests permissions that have privacy-preserving alternatives.
+---

--- a/tests-beta/android/MASVS-PRIVACY/MASTG-TEST-0256.md
+++ b/tests-beta/android/MASVS-PRIVACY/MASTG-TEST-0256.md
@@ -1,0 +1,8 @@
+---
+platform: android
+title: Missing Permission Rationale
+id: MASTG-TEST-0256
+weakness: MASWE-0117
+status: draft
+note: This test checks if the app does not provide a rationale for requesting permissions. See https://developer.android.com/training/permissions/requesting#explain and https://developer.android.com/training/permissions/explaining-access#privacy-dashboard-show-rationale
+---

--- a/tests-beta/android/MASVS-PRIVACY/MASTG-TEST-0257.md
+++ b/tests-beta/android/MASVS-PRIVACY/MASTG-TEST-0257.md
@@ -1,0 +1,8 @@
+---
+platform: android
+title: Not Resetting Unused Permissions
+id: MASTG-TEST-0257
+weakness: MASWE-0117
+status: draft
+note: This test checks if the app does not remove unnecessary access to granted permissions. See https://developer.android.com/training/permissions/requesting#remove-access
+---


### PR DESCRIPTION
Introduce three new draft test cases focused on privacy: 

- checking for minimized permission requests
- ensuring a rationale is provided for permissions
- verifying the reset of unused permissions.