### PR TITLE
Update MASTG-TEST-0254.md (Add missing type)

### DIFF
--- a/tests-beta/android/MASVS-PRIVACY/MASTG-TEST-0254.md
+++ b/tests-beta/android/MASVS-PRIVACY/MASTG-TEST-0254.md
@@ -1,7 +1,8 @@
 ---
-platform: android
 title: Dangerous App Permissions
+platform: android
 id: MASTG-TEST-0254
+type: [static]
 weakness: MASWE-0117
 ---
 


### PR DESCRIPTION
This PR adds the missing `type` field with the value `[static]` to the metadata section of `tests-beta/android/MASVS-PRIVACY/MASTG-TEST-0254.md`