### PR TITLE
Add draft for MASTG-TEST-0262: Backup Configurations Not Excluding Sensitive Data test

### DIFF
--- a/tests-beta/android/MASVS-STORAGE/MASTG-TEST-0262.md
+++ b/tests-beta/android/MASVS-STORAGE/MASTG-TEST-0262.md
@@ -1,0 +1,9 @@
+---
+platform: android
+title: References to Backup Configurations Not Excluding Sensitive Data
+id: MASTG-TEST-0262
+type: [static]
+weakness: MASWE-0004
+status: draft
+note: This test checks for the presence of backup rules in the AndroidManifest.xml and their configuration.
+---


### PR DESCRIPTION
Introduce a draft test to verify the presence of backup rules in the AndroidManifest.xml, ensuring sensitive data is not included in backups.