### PR TITLE
Add drafts for MASTG-TEST-0264, MASTG-TEST-0265, MASTG-DEMO-0038, MASTG-DEMO-0039 

### DIFF
--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0038/MASTG-DEMO-0038.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0038/MASTG-DEMO-0038.md
@@ -1,0 +1,34 @@
+---
+platform: android
+title: Detecting StrictMode Uses with Frida
+id: MASTG-DEMO-0038
+code: [kotlin]
+test: MASTG-TEST-0264
+status: draft
+note: This demo shows how to detect the use of StrictMode at runtime using Frida.
+---
+
+### Sample
+
+This sample demonstrates the detection of `StrictMode` uses at runtime using Frida. The app enables a `StrictMode` policy to detect leaked SQLite objects and intentionally leaves a cursor unclosed to trigger the policy.
+
+{{ ../MASTG-DEMO-0037/MastgTest.kt }}
+
+### Steps
+
+1. Install the app on a device (@MASTG-TECH-0005).
+2. Ensure you have @MASTG-TOOL-0001 installed on your machine and the frida-server running on the device.
+3. Run `run.sh` to spawn the app with Frida.
+4. Observe the Frida script output for detected `StrictMode` uses.
+
+{{ run.sh # script.js }}
+
+### Observation
+
+The Frida script output reveals the runtime usage of `StrictMode` policies, including the detection of leaked SQLite objects.
+
+{{ output.txt }}
+
+### Evaluation
+
+The test passes if the Frida script output shows the runtime usage of `StrictMode` policies. This demonstrates the app's behavior and the effectiveness of the `StrictMode` policy.

--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0038/MASTG-DEMO-0038.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0038/MASTG-DEMO-0038.md
@@ -7,28 +7,3 @@ test: MASTG-TEST-0264
 status: draft
 note: This demo shows how to detect the use of StrictMode at runtime using Frida.
 ---
-
-### Sample
-
-This sample demonstrates the detection of `StrictMode` uses at runtime using Frida. The app enables a `StrictMode` policy to detect leaked SQLite objects and intentionally leaves a cursor unclosed to trigger the policy.
-
-{{ ../MASTG-DEMO-0037/MastgTest.kt }}
-
-### Steps
-
-1. Install the app on a device (@MASTG-TECH-0005).
-2. Ensure you have @MASTG-TOOL-0001 installed on your machine and the frida-server running on the device.
-3. Run `run.sh` to spawn the app with Frida.
-4. Observe the Frida script output for detected `StrictMode` uses.
-
-{{ run.sh # script.js }}
-
-### Observation
-
-The Frida script output reveals the runtime usage of `StrictMode` policies, including the detection of leaked SQLite objects.
-
-{{ output.txt }}
-
-### Evaluation
-
-The test passes if the Frida script output shows the runtime usage of `StrictMode` policies. This demonstrates the app's behavior and the effectiveness of the `StrictMode` policy.

--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0039/MASTG-DEMO-0039.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0039/MASTG-DEMO-0039.md
@@ -7,27 +7,3 @@ test: MASTG-TEST-0265
 status: draft
 note: This demo shows how to detect the use of StrictMode in the codebase using Semgrep.
 ---
-
-### Sample
-
-This sample demonstrates the detection of `StrictMode` penalty log usage in the codebase using Semgrep. The rule identifies instances where `StrictMode.VmPolicy.Builder.penaltyLog()` is invoked.
-
-{{ ../MASTG-DEMO-0037/MastgTest.kt # MastgTest_reversed.java }}
-
-### Steps
-
-Let's run @MASTG-TOOL-0110 rules against the sample code.
-
-{{ ../../../../rules/mastg-android-strictmode.yml }}
-
-{{ run.sh }}
-
-### Observation
-
-The output shows all usages of APIs related to `StrictMode.setVmPolicy`.
-
-{{ output.txt }}
-
-### Evaluation
-
-The test fails because the output shows usages of `StrictMode` APIs, specifically: `StrictMode.setVmPolicy`.

--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0039/MASTG-DEMO-0039.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0039/MASTG-DEMO-0039.md
@@ -1,0 +1,33 @@
+---
+platform: android
+title: Detecting StrictMode PenaltyLog Usage with Semgrep
+id: MASTG-DEMO-0039
+code: [kotlin]
+test: MASTG-TEST-0265
+status: draft
+note: This demo shows how to detect the use of StrictMode in the codebase using Semgrep.
+---
+
+### Sample
+
+This sample demonstrates the detection of `StrictMode` penalty log usage in the codebase using Semgrep. The rule identifies instances where `StrictMode.VmPolicy.Builder.penaltyLog()` is invoked.
+
+{{ ../MASTG-DEMO-0037/MastgTest.kt # MastgTest_reversed.java }}
+
+### Steps
+
+Let's run @MASTG-TOOL-0110 rules against the sample code.
+
+{{ ../../../../rules/mastg-android-strictmode.yml }}
+
+{{ run.sh }}
+
+### Observation
+
+The output shows all usages of APIs related to `StrictMode.setVmPolicy`.
+
+{{ output.txt }}
+
+### Evaluation
+
+The test fails because the output shows usages of `StrictMode` APIs, specifically: `StrictMode.setVmPolicy`.

--- a/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0264.md
+++ b/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0264.md
@@ -8,21 +8,3 @@ best-practices: []
 status: draft
 note: This test checks whether the app uses StrictMode by placing relevant hooks to detect the use of StrictMode APIs, such as StrictMode.setVmPolicy and StrictMode.VmPolicy.Builder.penaltyLog().
 ---
-
-## Overview
-
-This test checks whether the app uses `StrictMode` by dynamically analyzing the app's behavior and placing relevant hooks to detect the use of `StrictMode` APIs, such as `StrictMode.setVmPolicy` and `StrictMode.VmPolicy.Builder.penaltyLog()`.
-
-While `StrictMode` is useful for developers to log policy violations such as disk I/O or network operations in production apps, it can expose sensitive implementation details in the logs that could be exploited by attackers.
-
-## Steps
-
-1. Run a dynamic analysis tool like @MASTG-TOOL-0039 and look for uses of `StrictMode` APIs.
-
-## Observation
-
-The output should show the runtime usage of `StrictMode` APIs.
-
-## Evaluation
-
-The test passes if the Frida script output shows the runtime usage of `StrictMode` APIs.

--- a/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0264.md
+++ b/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0264.md
@@ -1,0 +1,28 @@
+---
+platform: android
+title: Runtime Use of StrictMode APIs
+id: MASTG-TEST-0264
+type: [dynamic]
+weakness: MASWE-0094
+best-practices: []
+status: draft
+note: This test checks whether the app uses StrictMode by placing relevant hooks to detect the use of StrictMode APIs, such as StrictMode.setVmPolicy and StrictMode.VmPolicy.Builder.penaltyLog().
+---
+
+## Overview
+
+This test checks whether the app uses `StrictMode` by dynamically analyzing the app's behavior and placing relevant hooks to detect the use of `StrictMode` APIs, such as `StrictMode.setVmPolicy` and `StrictMode.VmPolicy.Builder.penaltyLog()`.
+
+While `StrictMode` is useful for developers to log policy violations such as disk I/O or network operations in production apps, it can expose sensitive implementation details in the logs that could be exploited by attackers.
+
+## Steps
+
+1. Run a dynamic analysis tool like @MASTG-TOOL-0039 and look for uses of `StrictMode` APIs.
+
+## Observation
+
+The output should show the runtime usage of `StrictMode` APIs.
+
+## Evaluation
+
+The test passes if the Frida script output shows the runtime usage of `StrictMode` APIs.

--- a/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0265.md
+++ b/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0265.md
@@ -8,20 +8,3 @@ best-practices: []
 status: draft
 note: This test checks whether the app uses StrictMode APIs, which can expose sensitive implementation details in the logs.
 ---
-
-## Overview
-
-This test checks whether the app uses `StrictMode`, which while useful for developers to log policy violations such as disk I/O or network operations in production apps, can expose sensitive implementation details in the logs that could be exploited by attackers.
-
-## Steps
-
-1. Use @MASTG-TOOL-0110 to identify all instances of `StrictMode`
-   APIs.
-
-## Observation
-
-The output should identify all instances of `StrictMode` usage in the app.
-
-## Evaluation
-
-The test fails if the app uses `StrictMode` APIs.

--- a/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0265.md
+++ b/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0265.md
@@ -1,0 +1,27 @@
+---
+platform: android
+title: References to StrictMode APIs
+id: MASTG-TEST-0265
+type: [static]
+weakness: MASWE-0094
+best-practices: []
+status: draft
+note: This test checks whether the app uses StrictMode APIs, which can expose sensitive implementation details in the logs.
+---
+
+## Overview
+
+This test checks whether the app uses `StrictMode`, which while useful for developers to log policy violations such as disk I/O or network operations in production apps, can expose sensitive implementation details in the logs that could be exploited by attackers.
+
+## Steps
+
+1. Use @MASTG-TOOL-0110 to identify all instances of `StrictMode`
+   APIs.
+
+## Observation
+
+The output should identify all instances of `StrictMode` usage in the app.
+
+## Evaluation
+
+The test fails if the app uses `StrictMode` APIs.


### PR DESCRIPTION
Introduce DRAFT demos and tests about `StrictMode` usage in Android applications, both at runtime using Frida and statically using Semgrep.