### PR TITLE
Fix broken blog by pinning dependencies (Workaround)

### DIFF
--- a/src/scripts/requirements.txt
+++ b/src/scripts/requirements.txt
@@ -1,9 +1,9 @@
-mkdocs
+mkdocs==1.6.0
+mkdocs-awesome-pages-plugin==2.9.2
+mkdocs-include-dir-to-nav==1.2.0
 mkdocs-material==9.5.27
-mkdocs-mermaid2-plugin
-mkdocs-include-dir-to-nav
-mkdocs-awesome-pages-plugin
-mkdocs-redirects
+mkdocs-mermaid2-plugin==1.1.1
+mkdocs-redirects==1.2.1
 pandas
 pyyaml
 tabulate

--- a/src/scripts/requirements.txt
+++ b/src/scripts/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs
-mkdocs-material
+mkdocs-material==9.5.27
 mkdocs-mermaid2-plugin
 mkdocs-include-dir-to-nav
 mkdocs-awesome-pages-plugin

--- a/src/scripts/requirements.txt
+++ b/src/scripts/requirements.txt
@@ -1,9 +1,9 @@
-mkdocs==1.6.0
+mkdocs==1.6.1
 mkdocs-awesome-pages-plugin==2.9.2
 mkdocs-include-dir-to-nav==1.2.0
-mkdocs-material==9.5.27
+mkdocs-material==9.6.11
 mkdocs-mermaid2-plugin==1.1.1
-mkdocs-redirects==1.2.1
+mkdocs-redirects==1.2.2
 pandas
 pyyaml
 tabulate


### PR DESCRIPTION
The problem was `mkdocs-awesome-pages-plugin`, using any version above `2.9.2` results in the blog index disappearing. This PR pins that dependency to `2.9.2` and other primary dependencies to the latest versions as of today. 

Closes #3243