### PR TITLE
MASWE-0069 draft: Add android risk reference for WebViews local resource access

### DIFF
--- a/weaknesses/MASVS-PLATFORM/MASWE-0069.md
+++ b/weaknesses/MASVS-PLATFORM/MASWE-0069.md
@@ -7,6 +7,8 @@ profiles: [L1, L2]
 mappings:
   masvs-v1: [MSTG-PLATFORM-6]
   masvs-v2: [MASVS-PLATFORM-2, MASVS-STORAGE-2]
+  android-risks:
+  - https://developer.android.com/privacy-and-security/risks/webview-unsafe-file-inclusion
 
 draft:
   description: use of setAllowFileAccessFromFileURLs. Mitigations include setAllowFileAccess(false),


### PR DESCRIPTION
This PR adds a new mapping under `android-risks` to include a link to the Android developer documentation on unsafe file inclusion in WebView to MASWE-0069.