### PR TITLE
Remove deprecation note in MASTG-TEST-0064 (added by mistake)

### DIFF
--- a/tests/ios/MASVS-AUTH/MASTG-TEST-0064.md
+++ b/tests/ios/MASVS-AUTH/MASTG-TEST-0064.md
@@ -8,9 +8,6 @@ platform: ios
 title: Testing Local Authentication
 masvs_v1_levels:
 - L2
-status: deprecated
-covered_by: [MASTG-TEST-0246, MASTG-TEST-0248]
-deprecation_note: New version available in MASTG V2
 ---
 
 ## Overview


### PR DESCRIPTION
Removed the `status: deprecated` status and other fields.