### PR TITLE
Update MASWE-0018.md draft

### DIFF
--- a/weaknesses/MASVS-CRYPTO/MASWE-0018.md
+++ b/weaknesses/MASVS-CRYPTO/MASWE-0018.md
@@ -12,15 +12,16 @@ refs:
 - https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder#setUnlockedDeviceRequired(boolean)
 - https://developer.apple.com/documentation/security/ksecattraccessiblewhenunlockedthisdeviceonly
 - https://developer.android.com/training/sign-in/biometric-auth#prompt-the-user-to-authenticate-with-biometrics
-- https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility#2974973
+- https://developer.apple.com/documentation/security/restricting-keychain-item-accessibility
 draft:
   description: Ensuring that cryptographic keys are accessible only under strict conditions,
     such as when the device is unlocked by an authenticated user, within secure application
-    contexts, or for limited periods of time, is critical to maintaining the confidentiality
+    contexts, bound to the current device, or for limited periods of time, is critical to maintaining the confidentiality
     and integrity of encrypted data.
   topics:
   - from a Background Process
   - locked device (iOS kSecAttrAccessibleWhenUnlockedThisDeviceOnly, Android setUnlockedDeviceRequired)
+  - device-bound or non-transferable (iOS ThisDeviceOnly)
   - time-based access (duration)
   - Require User Presence
   - application-specific password


### PR DESCRIPTION
* Fixed URL https://developer.apple.com/documentation/security/restricting-keychain-item-accessibility
* Revised the draft description to clarify that cryptographic keys can be bound to the current device in addition to being accessible only under strict conditions.
* Added a new topic to emphasize the importance of device-bound or non-transferable cryptographic keys (e.g., iOS `ThisDeviceOnly`).