### PR TITLE
Resolve logger warnings in MkDocs plugin

### DIFF
--- a/docs/hooks/maswe-beta-banner.py
+++ b/docs/hooks/maswe-beta-banner.py
@@ -27,7 +27,7 @@ def get_v1_tests_data():
                     
                     masvs_v1_tests_metadata[id] = frontmatter
             except:
-                log.warn("No frontmatter in " + file)
+                log.warning("No frontmatter in " + file)
 
     # Populate the defaultdict with MASVS v1 IDs and corresponding MASTG-TEST IDs
     masvs_v1_mapping = defaultdict(list)


### PR DESCRIPTION
Thank you for submitting a Pull Request to the OWASP MASTG. Please make sure that:

- [x] Your contribution is written in the 2nd person (e.g. you)
- [x] Your contribution is written in an active present form for as much as possible.
- [x] You have made sure that the reference section is up to date (e.g. please add sources you have used, make sure that the references to MITRE/MASVS/etc. are up to date)
- [x] Your contribution has proper formatted markdown and/or code
- [x] Any references to website have been formatted as [TEXT](URL “NAME”)
- [x] You verified/tested the effectiveness of your contribution (e.g.: is the code really an effective remediation? Please verify it works!)

This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```