### PR TITLE
Add demo implementation for insecure Keychain usage without user presence

### DIFF
--- a/demos/ios/MASVS-AUTH/MASTG-DEMO-0047/MASTG-DEMO-0047.md
+++ b/demos/ios/MASVS-AUTH/MASTG-DEMO-0047/MASTG-DEMO-0047.md
@@ -5,6 +5,27 @@ id: MASTG-DEMO-0047
 code: [swift]
 test: MASTG-TEST-0266
 kind: fail
-status: draft
-note: This demo shows how to store sensitive data insecurely in the Keychain by not requiring user presence (e.g., biometrics).
 ---
+
+### Sample
+
+This sample code demonstrates an insecure way of storing a token in the Keychain without requiring user presence. This happens in conjunction with the use of the LocalAuthentication framework to authenticate the user, giving a false sense of security.
+
+{{ MastgTest.swift }}
+
+### Steps
+
+1. Unzip the app package and locate the main binary file (@MASTG-TECH-0058), which in this case is `./Payload/MASTestApp.app/MASTestApp`.
+2. Run `run.sh`.
+
+{{ insecureAuthenticationBiometricsApi.r2 }}
+
+{{ run.sh }}
+
+### Observation
+
+{{ output.asm }}
+
+### Evaluation
+
+The test fails because the output shows references to biometric verification that uses LocalAuthentication API and the Keychain API but does not require user presence. 

--- a/demos/ios/MASVS-AUTH/MASTG-DEMO-0047/MastgTest.swift
+++ b/demos/ios/MASVS-AUTH/MASTG-DEMO-0047/MastgTest.swift
@@ -1,0 +1,60 @@
+import Foundation
+import LocalAuthentication
+import Security
+
+struct MastgTest {
+
+    static func mastgTest(completion: @escaping (String) -> Void) {
+        let account = "com.mastg.sectoken"
+        let tokenData = "8767086b9f6f976g-a8df76".data(using: .utf8)!
+
+        // 1. Store the token in the Keychain with no ACL flags, only protection
+        // 1a. Build your add‐item query
+        let storeQuery: [String: Any] = [
+            kSecClass as String:          kSecClassGenericPassword,
+            kSecAttrAccount as String:    account,
+            kSecValueData as String:      tokenData,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked
+        ]
+
+        // Before adding, we delete any existing item
+        SecItemDelete(storeQuery as CFDictionary)
+        let storeStatus = SecItemAdd(storeQuery as CFDictionary, nil)
+        guard storeStatus == errSecSuccess else {
+        completion("❌ Failed to store token in Keychain (status \(storeStatus))")
+        return
+        }
+
+        // 2. Now for retrieval, prompt the user explicitly with evaluatePolicy *from your app* (instead of letting the system do it)
+        let context = LAContext()
+        let reason  = "Authenticate to access your token"
+        context.evaluatePolicy(.deviceOwnerAuthenticationWithBiometrics,
+                               localizedReason: reason)
+        { success, error in
+            DispatchQueue.main.async {
+                guard success else {
+                    return completion("🔒 Authentication failed")
+                }
+
+                // 3) On success, pull the item from Keychain
+                let fetchQuery: [String: Any] = [
+                    kSecClass as String:         kSecClassGenericPassword,
+                    kSecAttrAccount as String:   account,
+                    kSecReturnData as String:    true,
+                    kSecMatchLimit as String:    kSecMatchLimitOne
+                ]
+
+                var result: CFTypeRef?
+                let fetchStatus = SecItemCopyMatching(fetchQuery as CFDictionary, &result)
+
+                if fetchStatus == errSecSuccess,
+                   let data = result as? Data,
+                   let token = String(data: data, encoding: .utf8) {
+                    completion("✅ Retrieved token: \(token)")
+                } else {
+                    completion("❌ Authentication failed or token inaccessible (status \(fetchStatus))")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introduce a demo for insecure storage of sensitive data in the Keychain, bypassing user presence requirements. This implementation highlights potential security risks associated with improper use of the LocalAuthentication framework.