### PR TITLE
Update MASWE-0088 Draft

### DIFF
--- a/weaknesses/MASVS-CODE/MASWE-0088.md
+++ b/weaknesses/MASVS-CODE/MASWE-0088.md
@@ -6,7 +6,8 @@ platform: [android, ios]
 profiles: [L2]
 mappings:
   masvs-v2: [MASVS-CODE-4]
-
+  android-risks: 
+  - https://developer.android.com/privacy-and-security/risks/unsafe-deserialization
 draft:
   description: e.g. XML, JSON, java.io.Serializable, Parcelable on Android or NSCoding
     on iOS.
@@ -17,6 +18,10 @@ draft:
   - Parcelable
   - NSCoding
 status: draft
-
+refs:
+- https://i.blackhat.com/EU-22/Wednesday-Briefings/EU-22-Ke-Android-Parcels-Introducing-Android-Safer-Parcel.pdf
+- https://github.com/michalbednarski/ReparcelBug2
+- https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html
+- https://blog.oversecured.com/Exploiting-memory-corruption-vulnerabilities-on-Android
 ---
 


### PR DESCRIPTION
* Added a new `android-risks` section with a link to Android's official documentation on unsafe deserialization risks.
* Added multiple references under the `refs` section, including a Black Hat presentation, a GitHub repository, an OWASP cheat sheet, and a blog post on exploiting memory corruption vulnerabilities on Android.