### PR TITLE
Add New iOS Pasteboard Tests MASTG-TEST-0278, MASTG-TEST-0279, MASTG-TEST-0280

### DIFF
--- a/Document/0x06h-Testing-Platform-Interaction.md
+++ b/Document/0x06h-Testing-Platform-Interaction.md
@@ -569,23 +569,18 @@ In addition:
 - No long-running background tasks are allowed but uploads or downloads can be initiated.
 - App extensions cannot access the camera or microphone on an iOS device (except for iMessage app extensions).
 
-#### UIPasteboard
+#### Pasteboard
 
-When typing data into input fields, the clipboard can be used to copy in data. The clipboard is accessible system-wide and is therefore shared by apps. This sharing can be misused by malicious apps to get sensitive data that has been stored in the clipboard.
+Apps can access the iOS pasteboard using the [`UIPasteboard`](https://developer.apple.com/documentation/uikit/uipasteboard) API. It allows apps to share data either within the app or across apps. However, the systemwide nature of the general pasteboard introduces privacy and security concerns, particularly when sensitive data is copied programatically without user interaction.
 
-When using an app you should be aware that other apps might be reading the clipboard continuously, as the [Facebook app](https://www.thedailybeast.com/facebook-is-spying-on-your-clipboard "Facebook Is Spying On Your Clipboard") did. Before iOS 9, a malicious app might monitor the pasteboard in the background while periodically retrieving `[UIPasteboard generalPasteboard].string`. As of iOS 9, pasteboard content is accessible to apps in the foreground only, which reduces the attack surface of password sniffing from the clipboard dramatically. Still, copy-pasting passwords is a security risk you should be aware of, but also cannot be solved by an app.
+There are two types of pasteboards:
 
-- Preventing pasting into input fields of an app, does not prevent that a user will copy sensitive information anyway. Since the information has already been copied before the user notices that it's not possible to paste it in, a malicious app has already sniffed the clipboard.
-- If pasting is disabled on password fields users might even choose weaker passwords that they can remember and they cannot use password managers anymore, which would contradict the original intention of making the app more secure.
+- **General pasteboard (`UIPasteboard.general`)**: Shared across all foreground apps and, with Universal Clipboard, potentially across Apple devices. Persistent by default across device restarts and app reinstalls unless cleared. Requires user interaction for access as of iOS 16.
+- **Custom or named pasteboards (`UIPasteboard(name:create:)`, `UIPasteboard.withUniqueName()`)**: App-specific or team-specific. Non-persistent by default since iOS 10 and restricted to the creating app or apps from the same team ID. Apple discourages using persistent custom pasteboards and recommends [using App Groups](https://developer.apple.com/documentation/Xcode/configuring-app-groups) for sharing data between apps of the same developer.
 
-The [`UIPasteboard`](https://developer.apple.com/documentation/uikit/uipasteboard "UIPasteboard") enables sharing data within an app, and from an app to other apps. There are two kinds of pasteboards:
+In earlier iOS versions, malicious apps could monitor the pasteboard from the background.
 
-- **systemwide general pasteboard**: for sharing data with any app. Persistent by default across device restarts and app uninstalls (since iOS 10).
-- **custom / named pasteboards**: for sharing data with another app (having the same team ID as the app to share from) or with the app itself (they are only available in the process that creates them). Non-persistent by default (since iOS 10), that is, they exist only until the owning (creating) app quits.
-
-**Security Considerations:**
-
-- Users cannot grant or deny permission for apps to read the pasteboard.
-- Since iOS 9, apps [cannot access the pasteboard while in background](https://forums.developer.apple.com/thread/13760 "UIPasteboard returning null from Today extension"), this mitigates background pasteboard monitoring. However, if the _malicious_ app is brought to foreground again and the data remains in the pasteboard, it will be able to retrieve it programmatically without the knowledge nor the consent of the user.
-- [Apple warns about persistent named pasteboards](https://developer.apple.com/documentation/uikit/uipasteboard?language=objc "Pasteboard Security and Privacy Changes in iOS 10") and discourages their use. Instead, shared containers should be used.
-- Starting in iOS 10 there is a new Handoff feature called Universal Clipboard that is enabled by default. It allows the general pasteboard contents to automatically transfer between devices. This feature can be disabled if the developer chooses to do so and it is also possible to set an expiration time and date for copied data.
+- Since iOS 9, access to the pasteboard is restricted to apps running in the foreground, significantly reducing the risk of passive clipboard sniffing. However, if sensitive data remains in the pasteboard and a malicious app is later brought to the foreground (or an app widget which is on the fireground everytime the user is on the screen it's located), it can still access that data without user consent or visibility. See [example attack](https://www.thedailybeast.com/facebook-is-spying-on-your-clipboard).
+- Since iOS 10, Universal Clipboard is enabled by default and, when a user signs into iCloud, automatically syncs the general pasteboard contents across the user's nearby Apple devices using the same iCloud account. Developers can choose to disable this (restricting the contents of the general pasteboard to the local device with `UIPasteboard.localOnly`) and may set expiration times for pasteboard items using `UIPasteboard.expirationDate`.
+- Since iOS 14, **the system notifies the user** when an app gets general pasteboard content that originates in a different app without user intent. The system determines user intent based on user interactions, such as tapping a system-provided control or pressing Command-V.
+- Since iOS 16, **the system now prompts users with a paste confirmation dialog** whenever an app accesses pasteboard content. Therefore, any access to the general pasteboard must be explicitly triggered by user interaction. Apps can also use [`UIPasteControl`](https://developer.apple.com/documentation/uikit/uipastecontrol) to handle paste actions by presenting a special "paste" button whnever they detect compatible data. This isn't necessarily better or more secure, it's a user experience improvement. It avoids prompting the user every time but the user still needs to click so in any case access occurs only in response to user interaction.

--- a/tests-beta/ios/MASVS-PLATFORM/MASTG-TEST-0276.md
+++ b/tests-beta/ios/MASVS-PLATFORM/MASTG-TEST-0276.md
@@ -32,3 +32,5 @@ The output should contain a list of locations where relevant APIs are used.
 ## Evaluation
 
 The test fails if there are calls to `UIPasteboard.generalPasteboard` and sensitive data is written to it.
+
+As determining what constitutes sensitive data is context-dependent, it can be challenging to detect statically. To determine whether sensitive data is being written to the pasteboard by the aforementioned methods, you can inspect the reported code locations in the reverse-engineered code (see @MASTG-TECH-0076).

--- a/tests-beta/ios/MASVS-PLATFORM/MASTG-TEST-0278.md
+++ b/tests-beta/ios/MASVS-PLATFORM/MASTG-TEST-0278.md
@@ -5,6 +5,23 @@ id: MASTG-TEST-0278
 type: [dynamic]
 weakness: MASWE-0053
 threat: [app]
-status: draft
-note: This test checks if the app clears the contents of the general pasteboard when it moves to the background or terminates.
 ---
+
+## Overview
+
+This test checks if the app clears the contents of the general [pasteboard](../../../Document/0x06h-Testing-Platform-Interaction.md/#pasteboard) when it moves to the background or terminates. If sensitive data is left in the pasteboard, it can be accessed by other apps, leading to potential data leaks.
+
+Apps can clear the contents of the general pasteboard by setting `UIPasteboard.general.items = []` in the appropriate lifecycle methods, such as `applicationDidEnterBackground:` or `applicationWillTerminate:`.
+
+## Steps
+
+1. Run a static analysis scan using @MASTG-TOOL-0073 to detect usage of the [`UIPasteboard.general`](https://developer.apple.com/documentation/uikit/uipasteboard/1622106-generalpasteboard "UIPasteboard generalPasteboard") property.
+2. Run a static analysis scan using @MASTG-TOOL-0073 to detect usage of the [`UIPasteboard.setItems`](https://developer.apple.com/documentation/uikit/uipasteboard/setitems(_:options:) "UIPasteboard setItems") method.
+
+## Observation
+
+The output should contain a list of locations where relevant APIs are used.
+
+## Evaluation
+
+The test fails if the app uses the general pasteboard and does not clear its contents when moving to the background or terminating. Specifically, it should be verified that there are calls to `UIPasteboard.setItems` with an empty array (`[]`) in the appropriate lifecycle methods.

--- a/tests-beta/ios/MASVS-PLATFORM/MASTG-TEST-0279.md
+++ b/tests-beta/ios/MASVS-PLATFORM/MASTG-TEST-0279.md
@@ -5,6 +5,21 @@ id: MASTG-TEST-0279
 type: [dynamic]
 weakness: MASWE-0053
 threat: [app]
-status: draft
-note: This test checks if the app sets an expiration date for the contents of the general pasteboard using the `UIPasteboard.setItems(_:options:)` method with the `UIPasteboard.Options.expirationDate` option. 
 ---
+
+## Overview
+
+This test checks if the app sets an expiration date for the contents of the general [pasteboard](../../../Document/0x06h-Testing-Platform-Interaction.md/#pasteboard) using the `UIPasteboard.setItems(_:options:)` method with the `UIPasteboard.Options.expirationDate` option. If sensitive data is left in the pasteboard without an expiration date, it can be accessed by other apps indefinitely, leading to potential data leaks.
+
+## Steps
+
+1. Run a static analysis scan using @MASTG-TOOL-0073 to detect usage of the [`UIPasteboard.general`](https://developer.apple.com/documentation/uikit/uipasteboard/1622106-generalpasteboard "UIPasteboard generalPasteboard") property.
+2. Run a static analysis scan using @MASTG-TOOL-0073 to detect usage of the `UIPasteboard.setItems(_:options:)` method.
+
+## Observation
+
+The output should contain a list of locations where relevant APIs are used.
+
+## Evaluation
+
+The test fails if the app uses the general pasteboard without setting an expiration date for its contents. Specifically, ensure that the `UIPasteboard.setItems(_:options:)` method is called with the `UIPasteboard.Options.expirationDate` option.

--- a/tests-beta/ios/MASVS-PLATFORM/MASTG-TEST-0280.md
+++ b/tests-beta/ios/MASVS-PLATFORM/MASTG-TEST-0280.md
@@ -5,6 +5,21 @@ id: MASTG-TEST-0280
 type: [dynamic]
 weakness: MASWE-0053
 threat: [app]
-status: draft
-note: This test checks if the app restricts the contents of the general pasteboard to the local device by using the `UIPasteboard.setItems(_:options:)` method with the `UIPasteboard.OptionsKey.localOnly` option.
 ---
+
+## Overview
+
+This test checks if the app restricts the contents of the general [pasteboard](../../../Document/0x06h-Testing-Platform-Interaction.md/#pasteboard) to the local device by using the `UIPasteboard.setItems(_:options:)` method with the `UIPasteboard.OptionsKey.localOnly` option. If sensitive data is placed in the general pasteboard without this restriction, it can be synced across devices via Universal Clipboard, leading to potential data leaks.
+
+## Steps
+
+1. Run a static analysis scan using @MASTG-TOOL-0073 to detect usage of the [`UIPasteboard.general`](https://developer.apple.com/documentation/uikit/uipasteboard/1622106-generalpasteboard "UIPasteboard generalPasteboard") property.
+2. Run a static analysis scan using @MASTG-TOOL-0073 to detect usage of the `UIPasteboard.setItems(_:options:)` method.
+
+## Observation
+
+The output should contain a list of locations where relevant APIs are used.
+
+## Evaluation
+
+The test fails if the app uses the general pasteboard without restricting its contents to the local device. Specifically, ensure that the `UIPasteboard.setItems(_:options:)` method is called with the `UIPasteboard.Options.localOnly` option.


### PR DESCRIPTION
This pull request introduces updates to the documentation and testing guidelines related to the iOS pasteboard (`UIPasteboard`). The changes focus on improving clarity, adding security considerations, and providing detailed testing steps for handling sensitive data in the pasteboard.

### Theory Update

* **Document/0x06h-Testing-Platform-Interaction**: Renamed the "UIPasteboard" section to "Pasteboard" and expanded its content to include detailed descriptions of general and custom pasteboards, their security implications, and iOS version-specific changes. New security features such as user notifications and paste confirmation dialogs in iOS 14 and iOS 16 were highlighted.

### Updated Tests

* **MASTG-TEST-0276**: Added a note clarifying the context-dependent nature of identifying sensitive data written to the pasteboard and linked it to reverse-engineering guidance.

### New Tests

* **MASTG-TEST-0278**: New test to verify that apps clear the general pasteboard contents when moving to the background or terminating. 
* **MASTG-TEST-0279**: New test to ensure that apps set an expiration date for pasteboard contents using the `UIPasteboard.Options.expirationDate` option.
* **MASTG-TEST-0280**: New test to verify that apps restrict pasteboard contents to the local device using the `UIPasteboard.OptionsKey.localOnly` option.