### PR TITLE
Remove 'status: new' from Android demo and test markdown files

### DIFF
--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0029/MASTG-DEMO-0029.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0029/MASTG-DEMO-0029.md
@@ -4,7 +4,6 @@ title: Uses of WebViews Allowing Content Access with semgrep
 id: MASTG-DEMO-0029
 code: [kotlin]
 test: MASTG-TEST-0250
-status: new
 ---
 
 ## Sample

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0030/MASTG-DEMO-0030.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0030/MASTG-DEMO-0030.md
@@ -4,7 +4,6 @@ title: Uses of WebViews Allowing Content Access with Frida
 id: MASTG-DEMO-0030
 code: [kotlin]
 test: MASTG-TEST-0251
-status: new
 ---
 
 ## Sample

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0031/MASTG-DEMO-0031.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0031/MASTG-DEMO-0031.md
@@ -4,7 +4,6 @@ title: Uses of WebViews Allowing Local File Access with Frida
 id: MASTG-DEMO-0031
 code: [kotlin]
 test: MASTG-TEST-0253
-status: new
 ---
 
 ## Sample

--- a/demos/android/MASVS-PLATFORM/MASTG-DEMO-0032/MASTG-DEMO-0032.md
+++ b/demos/android/MASVS-PLATFORM/MASTG-DEMO-0032/MASTG-DEMO-0032.md
@@ -4,7 +4,6 @@ title: Uses of WebViews Allowing Local File Access with semgrep
 id: MASTG-DEMO-0032
 code: [kotlin]
 test: MASTG-TEST-0252
-status: new
 ---
 
 ## Sample

--- a/demos/android/MASVS-PRIVACY/MASTG-DEMO-0033/MASTG-DEMO-0033.md
+++ b/demos/android/MASVS-PRIVACY/MASTG-DEMO-0033/MASTG-DEMO-0033.md
@@ -4,7 +4,6 @@ title: Dangerous Permissions in the AndroidManifest with semgrep
 id: MASTG-DEMO-0033
 code: [kotlin]
 test: MASTG-TEST-0254
-status: new
 ---
 
 ### Sample

--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0038/MASTG-DEMO-0038.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0038/MASTG-DEMO-0038.md
@@ -4,7 +4,6 @@ title: Detecting StrictMode Uses with Frida
 id: MASTG-DEMO-0038
 code: [kotlin]
 test: MASTG-TEST-0264
-status: new
 ---
 
 ### Sample

--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0039/MASTG-DEMO-0039.md
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0039/MASTG-DEMO-0039.md
@@ -4,7 +4,6 @@ title: Detecting StrictMode PenaltyLog Usage with Semgrep
 id: MASTG-DEMO-0039
 code: [kotlin]
 test: MASTG-TEST-0265
-status: new
 ---
 
 ### Sample

--- a/demos/android/MASVS-STORAGE/MASTG-DEMO-0020/MASTG-DEMO-0020.md
+++ b/demos/android/MASVS-STORAGE/MASTG-DEMO-0020/MASTG-DEMO-0020.md
@@ -4,7 +4,6 @@ title: Data Exclusion using backup_rules.xml with Backup Manager
 id: MASTG-DEMO-0020
 code: [kotlin]
 test: MASTG-TEST-0216
-status: new
 ---
 
 ### Sample

--- a/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0250.md
+++ b/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0250.md
@@ -7,7 +7,6 @@ apis: [WebView, WebSettings, getSettings, ContentProvider, setAllowContentAccess
 type: [static]
 weakness: MASWE-0069
 best-practices: [MASTG-BEST-0011, MASTG-BEST-0012, MASTG-BEST-0013]
-status: new
 ---
 
 ## Overview

--- a/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0251.md
+++ b/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0251.md
@@ -7,7 +7,6 @@ apis: [WebView, WebSettings, getSettings, ContentProvider, setAllowContentAccess
 type: [dynamic]
 weakness: MASWE-0069
 best-practices: [MASTG-BEST-0011, MASTG-BEST-0012, MASTG-BEST-0013]
-status: new
 ---
 
 ## Overview

--- a/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0252.md
+++ b/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0252.md
@@ -7,7 +7,6 @@ apis: [WebView, WebSettings, getSettings, setAllowFileAccess, setAllowFileAccess
 type: [static]
 weakness: MASWE-0069
 best-practices: [MASTG-BEST-0010, MASTG-BEST-0011, MASTG-BEST-0012]
-status: new
 ---
 
 ## Overview

--- a/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0253.md
+++ b/tests-beta/android/MASVS-PLATFORM/MASTG-TEST-0253.md
@@ -7,7 +7,6 @@ apis: [WebView, WebSettings, getSettings, setAllowFileAccess, setAllowFileAccess
 type: [dynamic]
 weakness: MASWE-0069
 best-practices: [MASTG-BEST-0010, MASTG-BEST-0011, MASTG-BEST-0012]
-status: new
 ---
 
 ## Overview

--- a/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0264.md
+++ b/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0264.md
@@ -5,7 +5,6 @@ id: MASTG-TEST-0264
 type: [dynamic]
 weakness: MASWE-0094
 best-practices: []
-status: new
 ---
 
 ## Overview

--- a/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0265.md
+++ b/tests-beta/android/MASVS-RESILIENCE/MASTG-TEST-0265.md
@@ -5,7 +5,6 @@ id: MASTG-TEST-0265
 type: [static]
 weakness: MASWE-0094
 best-practices: []
-status: new
 ---
 
 ## Overview


### PR DESCRIPTION
Eliminate the 'status: new' tag from multiple markdown files related to Android demos and tests.