### PR TITLE
Add docs for run website locally

### DIFF
--- a/docs/contributing/7_Run_the_Website.md
+++ b/docs/contributing/7_Run_the_Website.md
@@ -6,6 +6,8 @@ This guide will help you set up and run the OWASP MAS website locally on your ma
 >
 > - Setup a virtual environment
 > - Install dependencies from `src/scripts/requirements.txt`
+> - Install `brew install gnu-sed` (on macOS)
+> - In your .zshrc, add: [`export GITHUB_TOKEN=<TOKEN>`](https://github.com/settings/personal-access-tokens) and `alias sed='gsed'`
 > - Run the website using `./run_web.sh`
 
 ## Prerequisites

--- a/docs/contributing/7_Run_the_Website.md
+++ b/docs/contributing/7_Run_the_Website.md
@@ -65,7 +65,7 @@ Use vscode's [`Command Palette`](https://code.visualstudio.com/docs/getstarted/u
     - Press `⌘+Shift+P` -> `Python: Select Interpreter`
     - Choose the venv you just created.
 3. Install the dependencies
-   - Press `⌘ + j` to open the terminal
+   - Press `⌘+j` to open the terminal
    - Run `pip install -r src/scripts/requirements.txt`
 
 ## Step 4: Run the Website

--- a/docs/contributing/7_Run_the_Website.md
+++ b/docs/contributing/7_Run_the_Website.md
@@ -37,18 +37,16 @@ Use vscode's [`Command Palette`](https://code.visualstudio.com/docs/getstarted/u
 1. Create a venv:
     - Press `⌘+Shift+P` -> `Python: Create Environment`
     - Select `"Quick Create"`
-    
 2. Select the venv as the Python interpreter:
     - Press `⌘+Shift+P` -> `Python: Select Interpreter`
     - Choose the venv you just created.
-  
 3. Install the dependencies
    - Press `⌘ + j` to open the terminal
    - Run `pip install -r src/scripts/requirements.txt`
 
 ## Step 3: Install Gnu sed
 
-Install `gsed`, for exampe through brew on macOS:
+Install `gsed`, for example through brew on macOS:
 
 ```bash
 brew install gnu-sed
@@ -61,7 +59,6 @@ Execute the following command in the MASTG directory that you just checked out, 
 ```bash
 cd .. && git clone https://github.com/OWASP/owasp-masvs.git
 ```
-
 
 ## Step 5: Personal Access Token
 

--- a/docs/contributing/7_Run_the_Website.md
+++ b/docs/contributing/7_Run_the_Website.md
@@ -16,19 +16,41 @@ Before running the website, ensure you have the following installed on your syst
 - pip (Python package manager)
 - Git
 - Visual Studio Code (vscode)
-- Gnu sed (gsed)
+- Gnu sed (gsed; e.g. `brew install gnu-sed` on macOS)
 
-## Step 1: Open the OWASP MASTG Repository in vscode
+Add an alias for `gsed` (e.g. in your .zshrc file):
+
+```bash
+alias sed='gsed'
+```
+
+[Create a personal access token](https://github.com/settings/personal-access-tokens) on Github and export this token as environment variable (e.g. in your .zshrc file):
+
+```bash
+export GITHUB_TOKEN=<TOKEN>
+```
+
+## Step 1: Clone the OWASP MASVS & OWASP MASTG Repositories
 
 Run the following commands in your terminal:
 
 ```bash
+git clone https://github.com/OWASP/owasp-masvs.git
 git clone https://github.com/OWASP/owasp-mastg.git
+```
+
+**Note:** We'll just work with the `OWASP/owasp-mastg` repo, but the `OWASP/owasp-masvs` is required for the website to run.
+
+## Step 2: Open the OWASP MASTG Repository in vscode
+
+Run the following commands in your terminal:
+
+```bash
 cd owasp-mastg
 code .
 ```
 
-## Step 2: Install Dependencies
+## Step 3: Install Python Dependencies
 
 It is highly recommended to use a virtual environment (venv) to manage dependencies and avoid conflicts with other Python projects. Follow these steps to set up a virtual environment and install the required dependencies.
 
@@ -44,31 +66,7 @@ Use vscode's [`Command Palette`](https://code.visualstudio.com/docs/getstarted/u
    - Press `⌘ + j` to open the terminal
    - Run `pip install -r src/scripts/requirements.txt`
 
-## Step 3: Install Gnu sed
-
-Install `gsed`, for example through brew on macOS:
-
-```bash
-brew install gnu-sed
-```
-
-## Step 4: Checkout MASVS repository
-
-Execute the following command in the MASTG directory that you just checked out, to also clone the repo of the MASVS:
-
-```bash
-cd .. && git clone https://github.com/OWASP/owasp-masvs.git
-```
-
-## Step 5: Personal Access Token
-
-[Create a personal access token](https://github.com/settings/personal-access-tokens) on Github and export this token as environment variable:
-
-```bash
-export GITHUB_TOKEN=<TOKEN>
-```
-
-## Step 6: Run the Website
+## Step 4: Run the Website
 
 Run the following command in the terminal:
 
@@ -78,7 +76,7 @@ Run the following command in the terminal:
 
 Access the website at [http://localhost:8000](http://localhost:8000).
 
-## Step 7: Debugging the Website
+## Step 5: Debugging the Website
 
 To debug the website:
 

--- a/docs/contributing/7_Run_the_Website.md
+++ b/docs/contributing/7_Run_the_Website.md
@@ -16,6 +16,7 @@ Before running the website, ensure you have the following installed on your syst
 - pip (Python package manager)
 - Git
 - Visual Studio Code (vscode)
+- Gnu sed (gsed)
 
 ## Step 1: Open the OWASP MASTG Repository in vscode
 
@@ -36,15 +37,41 @@ Use vscode's [`Command Palette`](https://code.visualstudio.com/docs/getstarted/u
 1. Create a venv:
     - Press `⌘+Shift+P` -> `Python: Create Environment`
     - Select `"Quick Create"`
-
+    
 2. Select the venv as the Python interpreter:
     - Press `⌘+Shift+P` -> `Python: Select Interpreter`
     - Choose the venv you just created.
+  
 3. Install the dependencies
    - Press `⌘ + j` to open the terminal
    - Run `pip install -r src/scripts/requirements.txt`
 
-## Step 3: Run the Website
+## Step 3: Install Gnu sed
+
+Install `gsed`, for exampe through brew on macOS:
+
+```bash
+brew install gnu-sed
+```
+
+## Step 4: Checkout MASVS repository
+
+Execute the following command in the MASTG directory that you just checked out, to also clone the repo of the MASVS:
+
+```bash
+cd .. && git clone https://github.com/OWASP/owasp-masvs.git
+```
+
+
+## Step 5: Personal Access Token
+
+[Create a personal access token](https://github.com/settings/personal-access-tokens) on Github and export this token as environment variable:
+
+```bash
+export GITHUB_TOKEN=<TOKEN>
+```
+
+## Step 6: Run the Website
 
 Run the following command in the terminal:
 
@@ -54,7 +81,7 @@ Run the following command in the terminal:
 
 Access the website at [http://localhost:8000](http://localhost:8000).
 
-## Step 4: Debugging the Website
+## Step 7: Debugging the Website
 
 To debug the website:
 

--- a/docs/contributing/7_Run_the_Website.md
+++ b/docs/contributing/7_Run_the_Website.md
@@ -1,0 +1,64 @@
+# How to Run the OWASP MAS Website Locally
+
+This guide will help you set up and run the OWASP MAS website locally on your machine. Follow the steps below to get started.
+
+> **TLDR for advanced users:**
+>
+> - Setup a virtual environment
+> - Install dependencies from `src/scripts/requirements.txt`
+> - Run the website using `./run_web.sh`
+
+## Prerequisites
+
+Before running the website, ensure you have the following installed on your system:
+
+- Python 3.8 or higher
+- pip (Python package manager)
+- Git
+- Visual Studio Code (vscode)
+
+## Step 1: Open the OWASP MASTG Repository in vscode
+
+Run the following commands in your terminal:
+
+```bash
+git clone https://github.com/OWASP/owasp-mastg.git
+cd owasp-mastg
+code .
+```
+
+## Step 2: Install Dependencies
+
+It is highly recommended to use a virtual environment (venv) to manage dependencies and avoid conflicts with other Python projects. Follow these steps to set up a virtual environment and install the required dependencies.
+
+Use vscode's [`Command Palette`](https://code.visualstudio.com/docs/getstarted/userinterface#_command-palette) (Press `⌘+Shift+P` on macOS or `Ctrl+Shift+P` on Windows/Linux)
+
+1. Create a venv:
+    - Press `⌘+Shift+P` -> `Python: Create Environment`
+    - Select `"Quick Create"`
+
+2. Select the venv as the Python interpreter:
+    - Press `⌘+Shift+P` -> `Python: Select Interpreter`
+    - Choose the venv you just created.
+3. Install the dependencies
+   - Press `⌘ + j` to open the terminal
+   - Run `pip install -r src/scripts/requirements.txt`
+
+## Step 3: Run the Website
+
+Run the following command in the terminal:
+
+```bash
+./run_web.sh
+```
+
+Access the website at [http://localhost:8000](http://localhost:8000).
+
+## Step 4: Debugging the Website
+
+To debug the website:
+
+- Go to `Run and Debug` in vscode (or press `⌘+Shift+D` on macOS)
+- Select `Python: MkDocs Serve`
+- Click the green play button to start debugging
+- Set breakpoints in the code as needed


### PR DESCRIPTION
This pull request adds a new guide to the `docs/contributing/7_Run_the_Website.md` file, providing detailed instructions on how to set up and run the OWASP MAS website locally. The guide is structured with clear steps and includes prerequisites, setup commands, and debugging tips.
