### PR TITLE
Fix tags

### DIFF
--- a/docs/hooks/add-tags.py
+++ b/docs/hooks/add-tags.py
@@ -4,7 +4,8 @@ import mkdocs.plugins
 log = logging.getLogger('mkdocs')
 
 # https://www.mkdocs.org/dev-guide/plugins/#on_page_markdown
-@mkdocs.plugins.event_priority(-50)
+# mkdocs/tags runs at -50 so this has to be called before -50
+@mkdocs.plugins.event_priority(-49)
 def on_page_markdown(markdown, page, **kwargs):
     path = page.file.src_uri
 


### PR DESCRIPTION
This fixes the tags shown at the top of tests, which disappeared a while ago.

### Background info

mkdocs-material implemented a rewrite of the tags functionality in 9.6.0, which is used in the docker build command. For local runs, the requirements.txt weren't necessarily respected and I was running 9.5.x myself.

In the rewrite, the on_page_markdown trigger runs on priority -50 and should run last. Our add-tags on_page_markdown function also ran at -50, so the order is (probably?) undefined. By making it -49 we can be sure it runs before the mkdocs-material/tags plugin.