### PR TITLE
Add GitHub Actions workflow for website build checks

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/check-website-build.yml
+++ b/.github/workflows/check-website-build.yml
@@ -1,0 +1,40 @@
+name: Check Website Build
+on:
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: pip install -r src/scripts/requirements.txt
+
+      - run: bash -x ./src/scripts/structure_mastg.sh
+
+      - name: Get Latest MASVS Release Tag
+        run: echo "MASVS_VERSION=$(curl -s https://api.github.com/repos/OWASP/owasp-masvs/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          repository: "OWASP/owasp-masvs"
+          fetch-depth: 1
+          path: owasp-masvs/
+      - name: Generate MASVS yaml
+        run: python3 ./owasp-masvs/tools/generate_masvs_yaml.py -v ${{env.MASVS_VERSION}} -i ./owasp-masvs/Document -c ./owasp-masvs/controls
+      - name: Populate MASVS Categories Markdown Files
+        run: python3 ./owasp-masvs/tools/populate_masvs_categories_md.py -d ./owasp-masvs/Document -w
+      - run: ./src/scripts/structure_masvs.sh
+
+      - name: Generate MASVS Control Markdown Files
+        run: python3 src/scripts/write_masvs_control_md_files.py
+      
+      - name: Build website (no deploy)
+        run: mkdocs build --clean --verbose

--- a/.github/workflows/check-website-build.yml
+++ b/.github/workflows/check-website-build.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Closes #3324

* [`.github/workflows/check-website-build.yml`](diffhunk://#diff-6284d2d945d9134c3769fe6d8a0f2749b5568872171ba07696aecf158a1b0b5bR1-R40): Added a new workflow named "Check Website Build" to validate the website's build process on pull requests without deploying it.

* [`.github/workflows/build-website.yml`](diffhunk://#diff-bbc95c597ac5c7abf10c841501a235bb91d15c710ca51a5f343cee0f2a7541beL14-R14): Changed the `fetch-depth` parameter in the `actions/checkout` step from `0` to `1` to optimize the checkout process by fetching only the latest commit.