### PR TITLE
Add reusable GitHub Actions workflow for website build and deploy

### DIFF
--- a/.github/workflows/build-website-reusable.yml
+++ b/.github/workflows/build-website-reusable.yml
@@ -1,0 +1,53 @@
+name: Build Website (Reusable)
+on:
+  workflow_call:
+    inputs:
+      deploy:
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      GITHUB_TOKEN:
+        required: false
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: pip install -r src/scripts/requirements.txt
+
+      - run: bash -x ./src/scripts/structure_mastg.sh
+
+      - name: Get Latest MASVS Release Tag
+        run: echo "MASVS_VERSION=$(curl -s https://api.github.com/repos/OWASP/owasp-masvs/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          repository: "OWASP/owasp-masvs"
+          fetch-depth: 1
+          path: owasp-masvs/
+      - name: Generate MASVS yaml
+        run: python3 ./owasp-masvs/tools/generate_masvs_yaml.py -v ${{env.MASVS_VERSION}} -i ./owasp-masvs/Document -c ./owasp-masvs/controls
+      - name: Populate MASVS Categories Markdown Files
+        run: python3 ./owasp-masvs/tools/populate_masvs_categories_md.py -d ./owasp-masvs/Document -w
+      - run: ./src/scripts/structure_masvs.sh
+
+      - name: Generate MASVS Control Markdown Files
+        run: python3 src/scripts/write_masvs_control_md_files.py
+      
+      - name: Build website (no deploy)
+        if: ${{ !inputs.deploy }}
+        run: mkdocs build --clean --verbose
+
+      - name: Deploy to GitHub Pages
+        if: ${{ inputs.deploy }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mkdocs gh-deploy --force --clean --verbose

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -9,36 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'cpholguera' || github.actor == 'sushi2k' || github.actor == 'TheDauntless'
     steps:
-      - uses: actions/checkout@v4
+      - name: Call reusable build workflow and deploy
+        uses: ./.github/workflows/build-website-reusable.yml
         with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Install dependencies
-        run: pip install -r src/scripts/requirements.txt
-
-      - run: bash -x ./src/scripts/structure_mastg.sh
-
-      - name: Get Latest MASVS Release Tag
-        run: echo "MASVS_VERSION=$(curl -s https://api.github.com/repos/OWASP/owasp-masvs/releases/latest | jq '.tag_name' | sed 's/\"//g')" >> $GITHUB_ENV
-
-      - uses: actions/checkout@v4
-        with:
-          repository: "OWASP/owasp-masvs"
-          fetch-depth: 1
-          path: owasp-masvs/
-      - name: Generate MASVS yaml
-        run: python3 ./owasp-masvs/tools/generate_masvs_yaml.py -v ${{env.MASVS_VERSION}} -i ./owasp-masvs/Document -c ./owasp-masvs/controls
-      - name: Populate MASVS Categories Markdown Files
-        run: python3 ./owasp-masvs/tools/populate_masvs_categories_md.py -d ./owasp-masvs/Document -w
-      - run: ./src/scripts/structure_masvs.sh
-
-      - name: Generate MASVS Control Markdown Files
-        run: python3 src/scripts/write_masvs_control_md_files.py
-      
-      - name: Deploy to GitHub Pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: mkdocs gh-deploy --force --clean --verbose
+          deploy: true

--- a/.github/workflows/check-website-build.yml
+++ b/.github/workflows/check-website-build.yml
@@ -1,0 +1,13 @@
+name: Check Website Build
+on:
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call reusable build workflow (no deploy)
+        uses: ./.github/workflows/build-website-reusable.yml
+        with:
+          deploy: false


### PR DESCRIPTION
Introduce a reusable workflow for building and deploying the website, streamlining the process for both pull requests and direct deployments. This includes a check for the website build on pull requests and the option to deploy to GitHub Pages.