### PR TITLE
Update-MASTG-TECH-0117

### DIFF
--- a/Document/0x05a-Platform-Overview.md
+++ b/Document/0x05a-Platform-Overview.md
@@ -268,10 +268,10 @@ Security-relevant elements include:
 
 - **Permissions:** Declares required permissions using `<uses-permission>` such as access to the internet, camera, storage, location, or contacts. These define the app's access boundaries and should follow the principle of least privilege. Custom permissions can be defined using `<permission>` and should include a proper `protectionLevel` such as `signature` or `dangerous` to avoid being misused by other apps.
 - **Components:** The manifest lists all [app components](#app-components) declared in the app serving as entry points. They can be exposed to other apps (via intent filters or the `exported` attribute) so they are critical to determine how an attacker might interact with the app. The main component types are:
-    - **Activities:** define user interface screens. If associated with intent filters and not properly restricted, they may be invoked by other apps.
-    - **Services:** run background tasks. Exported services can be invoked externally, so should be secured if not meant for public use.
-    - **Broadcast Receivers:** handle external messages. Unprotected receivers are a common attack surface.
-    - **Content Providers:** expose structured data. Improper permissions can lead to unauthorized read or write access.
+    - **Activities:** define user interface screens.
+    - **Services:** run background tasks.
+    - **Broadcast Receivers:** handle external messages.
+    - **Content Providers:** expose structured data.
 - **Deep Links:** [Deep links](0x05h-Testing-Platform-Interaction.md#deep-links) are configured via intent filters with the `VIEW` action, `BROWSABLE` category, and a `data` element specifying a URI pattern. These can expose activities to web or app links and must be verified carefully to avoid injection or spoofing risks. Adding `android:autoVerify="true"` enables App Links, which restrict handling of verified links to the declared app, reducing the risk of link hijacking.
 - **Uses Cleartext Traffic:** The `android:usesCleartextTraffic` attribute controls whether the app allows non-encrypted HTTP traffic. From Android 9 (API 28) onward, cleartext traffic is disabled by default unless explicitly allowed. This attribute can also be overridden by the `networkSecurityConfig`.
 - **Network Security Config:** An optional XML file defined via `android:networkSecurityConfig`, available since Android 7.0 (API level 24), that provides granular control over [network security behavior](0x05g-Testing-Network-Communication.md#android-network-security-configuration). It allows specifying trusted certificate authorities, per-domain TLS requirements, and cleartext traffic exceptions, overriding global settings defined in `android:usesCleartextTraffic`.

--- a/Document/0x05a-Platform-Overview.md
+++ b/Document/0x05a-Platform-Overview.md
@@ -262,48 +262,138 @@ We recommend that you test both the APK with and without the additional modules,
 
 ### Android Manifest
 
-Every app has an Android Manifest file, which embeds content in binary XML format. The standard name of this file is AndroidManifest.xml. It is located in the root directory of the app's Android Package Kit (APK) file.
+Every Android app contains an `AndroidManifest.xml` file in the root of its APK, written in binary XML format. This file defines the app's structure and key properties used by the Android operating system during installation and runtime.
 
-The manifest file describes the app structure, its components (activities, services, content providers, and intent receivers), and requested permissions. It also contains general app metadata, such as the app's icon, version number, and theme. The file may list other information, such as compatible APIs (minimal, targeted, and maximal SDK version) and the [kind of storage it can be installed on (external or internal)](https://developer.android.com/guide/topics/data/install-location.html "Define app install location").
+Security-relevant elements include:
 
-Here is an example of a manifest file, including the package name (the convention is a reversed URL, but any string is acceptable). It also lists the app version, relevant SDKs, required permissions, exposed content providers, broadcast receivers used with intent filters and a description of the app and its activities:
+- **Permissions:** Declares required permissions using `<uses-permission>` such as access to the internet, camera, storage, location, or contacts. These define the app's access boundaries and should follow the principle of least privilege. Custom permissions can be defined using `<permission>` and should include a proper `protectionLevel` such as `signature` or `dangerous` to avoid being misused by other apps.
+- **Components:** The manifest lists all [app components](#app-components) declared in the app serving as entry points. They can be exposed to other apps (via intent filters or the `exported` attribute) so they are critical to determine how an attacker might interact with the app. The main component types are:
+    - **Activities:** define user interface screens. If associated with intent filters and not properly restricted, they may be invoked by other apps.
+    - **Services:** run background tasks. Exported services can be invoked externally, so should be secured if not meant for public use.
+    - **Broadcast Receivers:** handle system-wide messages. Unprotected receivers are a common attack surface.
+    - **Content Providers:** expose structured data. Improper permissions can lead to unauthorized read or write access.
+- **Deep Links:** [Deep links](0x05h-Testing-Platform-Interaction.md#deep-links) are configured via intent filters with the `VIEW` action, `BROWSABLE` category, and a `data` element specifying a URI pattern. These can expose activities to web or app links and must be verified carefully to avoid injection or spoofing risks. Adding `android:autoVerify="true"` enables App Links, which restrict handling of verified links to the declared app, reducing the risk of link hijacking.
+- **Uses Cleartext Traffic:** The `android:usesCleartextTraffic` attribute controls whether the app allows non-encrypted HTTP traffic. From Android 9 (API 28) onward, cleartext traffic is disabled by default unless explicitly allowed. This attribute can be overridden by the `networkSecurityConfig`.
+- **Network Security Config:** An optional XML file defined via `android:networkSecurityConfig`, available since Android 7.0 (API level 24), that provides granular control over [network security behavior](0x05g-Testing-Network-Communication.md#android-network-security-configuration). It allows specifying trusted certificate authorities, per-domain TLS requirements, and cleartext traffic exceptions, overriding global settings defined in `android:usesCleartextTraffic`.
+- **Backup Behavior:** The `android:allowBackup` attribute allows or prevents app data from being [backed up](0x05d-Testing-Data-Storage.md#backups).
+- **Task Affinities and Launch Modes:** These settings influence how activities are grouped and launched. Misconfigurations can allow task hijacking or phishing-style attacks if an attacker's app mimics legitimate components.
+- **Install Location:** Specifies whether the APK file can be installed on external storage. Regardless, all private app data, optimized DEX files, and native libraries are stored on internal device memory.
+
+The full list of available manifest options is in the official [Android Manifest file documentation](https://developer.android.com/guide/topics/manifest/manifest-intro.html "Android Developer Guide for Manifest").
+
+At build time, the manifest is merged with those from all included libraries and dependencies. The final merged manifest may include additional permissions, components, or settings not explicitly declared by the developer. Security reviews must analyze the merged output to understand the app's real exposure.
+
+Here is an example of a manifest file as defined by a developer. It declares several permissions, allows backup, and defines the app's main activity:
 
 ```xml
-<manifest
-    package="com.owasp.myapplication"
-    android:versionCode="0.1" >
-
-    <uses-sdk android:minSdkVersion="12"
-        android:targetSdkVersion="22"
-        android:maxSdkVersion="25" />
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
-
-    <provider
-        android:name="com.owasp.myapplication.MyProvider"
-        android:exported="false" />
-
-    <receiver android:name=".MyReceiver" >
-        <intent-filter>
-            <action android:name="com.owasp.myapplication.myaction" />
-        </intent-filter>
-    </receiver>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
-        android:icon="@drawable/ic_launcher"
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.Material.Light" >
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.MASTestApp"
+        tools:targetApi="31">
         <activity
-            android:name="com.owasp.myapplication.MainActivity" >
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.MASTestApp">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
     </application>
+
 </manifest>
 ```
 
-The full list of available manifest options is in the official [Android Manifest file documentation](https://developer.android.com/guide/topics/manifest/manifest-intro.html "Android Developer Guide for Manifest").
+If you were to obtain the AndroidManifest.xml file from an APK (@MASTG-TECH-0117), you would see that it includes additional elements such as the `package` attribute, which defines the app's unique identifier, the `<uses-sdk>` element that specifies the `android:minSdkVersion` and `android:targetSdkVersion`, new activities, providers and receivers and other attributes such as `android:debuggable="true"` which indicates that the app is in debug mode.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0"
+    android:compileSdkVersion="35"
+    android:compileSdkVersionCodename="15"
+    package="org.owasp.mastestapp"
+    platformBuildVersionCode="35"
+    platformBuildVersionName="15">
+    <uses-sdk
+        android:minSdkVersion="29"
+        android:targetSdkVersion="35"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_CONTACTS"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <permission
+        android:name="org.owasp.mastestapp.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"
+        android:protectionLevel="signature"/>
+    <uses-permission android:name="org.owasp.mastestapp.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"/>
+    <application
+        android:theme="@style/Theme.MASTestApp"
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:debuggable="true"
+        android:testOnly="true"
+        android:allowBackup="true"
+        android:supportsRtl="true"
+        android:extractNativeLibs="false"
+        android:fullBackupContent="@xml/backup_rules"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:appComponentFactory="androidx.core.app.CoreComponentFactory"
+        android:dataExtractionRules="@xml/data_extraction_rules">
+        <activity
+            android:theme="@style/Theme.MASTestApp"
+            android:name="org.owasp.mastestapp.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+        <activity
+            android:name="androidx.compose.ui.tooling.PreviewActivity"
+            android:exported="true"/>
+        <activity
+            android:name="androidx.activity.ComponentActivity"
+            android:exported="true"/>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:exported="false"
+            android:authorities="org.owasp.mastestapp.androidx-startup">
+            <meta-data
+                android:name="androidx.emoji2.text.EmojiCompatInitializer"
+                android:value="androidx.startup"/>
+            ...
+        </provider>
+        <receiver
+            android:name="androidx.profileinstaller.ProfileInstallReceiver"
+            android:permission="android.permission.DUMP"
+            android:enabled="true"
+            android:exported="true"
+            android:directBootAware="false">
+            <intent-filter>
+                <action android:name="androidx.profileinstaller.action.INSTALL_PROFILE"/>
+            </intent-filter>
+            ...
+        </receiver>
+    </application>
+</manifest>
+```
 
 ### App Components
 

--- a/Document/0x05a-Platform-Overview.md
+++ b/Document/0x05a-Platform-Overview.md
@@ -262,7 +262,7 @@ We recommend that you test both the APK with and without the additional modules,
 
 ### Android Manifest
 
-Every Android app contains an `AndroidManifest.xml` file in the root of its APK, written in binary XML format. This file defines the app's structure and key properties used by the Android operating system during installation and runtime.
+Every Android app contains an `AndroidManifest.xml` file in the root of the APK, stored in binary XML format. This file defines the app's structure and key properties used by the Android operating system during installation and runtime.
 
 Security-relevant elements include:
 
@@ -270,16 +270,15 @@ Security-relevant elements include:
 - **Components:** The manifest lists all [app components](#app-components) declared in the app serving as entry points. They can be exposed to other apps (via intent filters or the `exported` attribute) so they are critical to determine how an attacker might interact with the app. The main component types are:
     - **Activities:** define user interface screens. If associated with intent filters and not properly restricted, they may be invoked by other apps.
     - **Services:** run background tasks. Exported services can be invoked externally, so should be secured if not meant for public use.
-    - **Broadcast Receivers:** handle system-wide messages. Unprotected receivers are a common attack surface.
+    - **Broadcast Receivers:** handle external messages. Unprotected receivers are a common attack surface.
     - **Content Providers:** expose structured data. Improper permissions can lead to unauthorized read or write access.
 - **Deep Links:** [Deep links](0x05h-Testing-Platform-Interaction.md#deep-links) are configured via intent filters with the `VIEW` action, `BROWSABLE` category, and a `data` element specifying a URI pattern. These can expose activities to web or app links and must be verified carefully to avoid injection or spoofing risks. Adding `android:autoVerify="true"` enables App Links, which restrict handling of verified links to the declared app, reducing the risk of link hijacking.
-- **Uses Cleartext Traffic:** The `android:usesCleartextTraffic` attribute controls whether the app allows non-encrypted HTTP traffic. From Android 9 (API 28) onward, cleartext traffic is disabled by default unless explicitly allowed. This attribute can be overridden by the `networkSecurityConfig`.
+- **Uses Cleartext Traffic:** The `android:usesCleartextTraffic` attribute controls whether the app allows non-encrypted HTTP traffic. From Android 9 (API 28) onward, cleartext traffic is disabled by default unless explicitly allowed. This attribute can also be overridden by the `networkSecurityConfig`.
 - **Network Security Config:** An optional XML file defined via `android:networkSecurityConfig`, available since Android 7.0 (API level 24), that provides granular control over [network security behavior](0x05g-Testing-Network-Communication.md#android-network-security-configuration). It allows specifying trusted certificate authorities, per-domain TLS requirements, and cleartext traffic exceptions, overriding global settings defined in `android:usesCleartextTraffic`.
 - **Backup Behavior:** The `android:allowBackup` attribute allows or prevents app data from being [backed up](0x05d-Testing-Data-Storage.md#backups).
 - **Task Affinities and Launch Modes:** These settings influence how activities are grouped and launched. Misconfigurations can allow task hijacking or phishing-style attacks if an attacker's app mimics legitimate components.
-- **Install Location:** Specifies whether the APK file can be installed on external storage. Regardless, all private app data, optimized DEX files, and native libraries are stored on internal device memory.
 
-The full list of available manifest options is in the official [Android Manifest file documentation](https://developer.android.com/guide/topics/manifest/manifest-intro.html "Android Developer Guide for Manifest").
+The full list of available manifest options can be found in the official [Android Manifest file documentation](https://developer.android.com/guide/topics/manifest/manifest-intro.html "Android Developer Guide for Manifest").
 
 At build time, the manifest is merged with those from all included libraries and dependencies. The final merged manifest may include additional permissions, components, or settings not explicitly declared by the developer. Security reviews must analyze the merged output to understand the app's real exposure.
 

--- a/techniques/android/MASTG-TECH-0117.md
+++ b/techniques/android/MASTG-TECH-0117.md
@@ -5,7 +5,7 @@ platform: android
 
 The [AndroidManifest.xml](../../Document/0x05a-Platform-Overview.md) file is a critical component of any Android application, providing essential information about the app's structure, permissions, components, and configurations. During a security assessment, analyzing the manifest can reveal potential vulnerabilities or misconfigurations that could be exploited by attackers.
 
-The AndroidManifest can be obtained from the APK file, and if you try to open it directly, you might see it's in a binary format. To properly analyze the manifest, you need to extract and decode it into a human-readable XML format.
+The AndroidManifest is stored in a binary XML format and cannot simply be extracted from the APK by unzipping it. To properly analyze the manifest, you first need to extract and decode it into a human-readable XML format.
 
 Different tools extract the manifest in various formats, with some preserving more raw structure while others interpret or modify it during decoding.
 
@@ -29,7 +29,7 @@ jadx outputs the manifest in full to `out_dir/resources/AndroidManifest.xml`, in
 
 ## Using @MASTG-TOOL-0011
 
-The full AndroidManifest can be extracted using apktool:
+The AndroidManifest can be extracted using apktool:
 
 ```sh
 $ apktool d -s -f -o output_dir MASTG-DEMO-0001.apk
@@ -56,7 +56,6 @@ sdkInfo:
   targetSdkVersion: 35
 ```
 
-If you need to modify and rebuild the manifest with different SDK values, you'd update that sdkInfo section in apktool.yml and rebuild using apktool b.
 
 ## Using @MASTG-TOOL-0124
 

--- a/techniques/android/MASTG-TECH-0117.md
+++ b/techniques/android/MASTG-TECH-0117.md
@@ -60,7 +60,7 @@ If you need to modify and rebuild the manifest with different SDK values, you'd 
 
 ## Using @MASTG-TOOL-0124
 
-If you are only interested in specific values of the manifest, you can alternatively use aapt2.
+If you are only interested in specific values of the manifest, you can use aapt2.
 
 Note that **the output is not an XML file**.
 

--- a/techniques/android/MASTG-TECH-0117.md
+++ b/techniques/android/MASTG-TECH-0117.md
@@ -17,7 +17,7 @@ Use jadx CLI with `--no-src` to extract only resources without decompiling all s
 jadx --no-src -d out_dir MASTG-DEMO-0001.apk
 ```
 
-jadx outputs the manifest in full to `out_dir/resources/AndroidManifest.xml`, including the `<uses-sdk>` element which is not included when using other
+jadx outputs the manifest in full to `out_dir/resources/AndroidManifest.xml`, including the `<uses-sdk>` element which is not included when using other tools like apktool.
 
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
@@ -33,7 +33,7 @@ The full AndroidManifest can be extracted using apktool:
 
 ```sh
 $ apktool d -s -f -o output_dir MASTG-DEMO-0001.apk
-I: Using Apktool 2.11.1 on temp_base.apk with 8 threads
+I: Using Apktool 2.11.1 on MASTG-DEMO-0001.apk with 8 threads
 I: Copying raw classes.dex file...
 ...
 I: Loading resource table...
@@ -62,7 +62,7 @@ If you need to modify and rebuild the manifest with different SDK values, you'd 
 
 If you are only interested in specific values of the manifest, you can alternatively use aapt2.
 
-Note that **the output is not a XML file**.
+Note that **the output is not an XML file**.
 
 ```bash
 $ aapt2 d badging MASTG-DEMO-0001.apk

--- a/techniques/android/MASTG-TECH-0117.md
+++ b/techniques/android/MASTG-TECH-0117.md
@@ -3,43 +3,72 @@ title: Obtaining Information from the AndroidManifest
 platform: android 
 ---
 
-Multiple ways exist to view the contents of the AndroidManifest:
+The [AndroidManifest.xml](../../Document/0x05a-Platform-Overview.md) file is a critical component of any Android application, providing essential information about the app's structure, permissions, components, and configurations. During a security assessment, analyzing the manifest can reveal potential vulnerabilities or misconfigurations that could be exploited by attackers.
+
+The AndroidManifest can be obtained from the APK file, and if you try to open it directly, you might see it's in a binary format. To properly analyze the manifest, you need to extract and decode it into a human-readable XML format.
+
+Different tools extract the manifest in various formats, with some preserving more raw structure while others interpret or modify it during decoding.
+
+## Using @MASTG-TOOL-0018
+
+Use jadx CLI with `--no-src` to extract only resources without decompiling all sources:
+
+```sh
+jadx --no-src -d out_dir MASTG-DEMO-0001.apk
+```
+
+jadx outputs the manifest in full to `out_dir/resources/AndroidManifest.xml`, including the `<uses-sdk>` element which is not included when using other
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" ...>
+    <uses-sdk
+        android:minSdkVersion="29"
+        android:targetSdkVersion="35" />
+```
 
 ## Using @MASTG-TOOL-0011
 
-The full AndroidManifest can be extracted using @MASTG-TOOL-0011:
+The full AndroidManifest can be extracted using apktool:
 
 ```sh
-$ apktool d myapp.apk -s -o apktooled_app
-I: Using Apktool 2.7.0 on myapp.apk
+$ apktool d -s -f -o output_dir MASTG-DEMO-0001.apk
+I: Using Apktool 2.11.1 on temp_base.apk with 8 threads
+I: Copying raw classes.dex file...
+...
 I: Loading resource table...
-I: Decoding AndroidManifest.xml with resources...
-I: Loading resource table from file: /home/.local/share/apktool/framework/1.apk
-I: Regular manifest package...
 I: Decoding file-resources...
 I: Decoding values */* XMLs...
-I: Copying raw classes.dex file...
-I: Copying assets and libs...
-I: Copying unknown files...
-I: Copying original files...
-I: Copying META-INF/services directory
+I: Decoding AndroidManifest.xml with resources...
 ```
 
 `-s` skips baksmaliing the dex files and is faster.
 
-The AndroidManifest.xml is extracted and decoded to `apktooled_app/AndroidManifest.xml`, where you can simply open and view it.
+The AndroidManifest.xml is extracted and decoded to `output_dir/AndroidManifest.xml`, where you can simply open and view it.
+
+When you decode an APK with apktool, you might notice that the `<uses‑sdk>` element (which includes `minSdkVersion` and `targetSdkVersion`) is missing from the decompiled AndroidManifest.xml. That's expected behavior.
+
+Apktool moves those values into a separate file called apktool.yml rather than inserting them into the decoded XML manifest. In that file you'll see something like:
+
+```yml
+sdkInfo:
+  minSdkVersion: 29
+  targetSdkVersion: 35
+```
+
+If you need to modify and rebuild the manifest with different SDK values, you'd update that sdkInfo section in apktool.yml and rebuild using apktool b.
 
 ## Using @MASTG-TOOL-0124
 
-If you are only interested in specific values of the manifest, you can use alternatively use @MASTG-TOOL-0124. Please note that the output is not a XML file.
+If you are only interested in specific values of the manifest, you can alternatively use aapt2.
 
-Viewing all contents of the AndroidManifest can be performed with:
+Note that **the output is not a XML file**.
 
 ```bash
-$ aapt d badging MASTG-DEMO-0001.apk
-package: name='org.owasp.mastestapp' versionCode='1' versionName='1.0' platformBuildVersionName='14' platformBuildVersionCode='34' compileSdkVersion='34' compileSdkVersionCodename='14'
+$ aapt2 d badging MASTG-DEMO-0001.apk
+package: name='org.owasp.mastestapp' versionCode='1' versionName='1.0' platformBuildVersionName='15' platformBuildVersionCode='35' compileSdkVersion='35' compileSdkVersionCodename='15'
 sdkVersion:'29'
-targetSdkVersion:'34'
+targetSdkVersion:'35'
 uses-permission: name='android.permission.INTERNET'
 uses-permission: name='org.owasp.mastestapp.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION'
 application-label:'MASTestApp'

--- a/techniques/android/MASTG-TECH-0117.md
+++ b/techniques/android/MASTG-TECH-0117.md
@@ -56,7 +56,6 @@ sdkInfo:
   targetSdkVersion: 35
 ```
 
-
 ## Using @MASTG-TOOL-0124
 
 If you are only interested in specific values of the manifest, you can use aapt2.


### PR DESCRIPTION
Improve guidance on extracting the AndroidManifest and include detailed security considerations and examples to aid in vulnerability assessments.

### Document/0x05a-Platform-Overview.md:
* Expanded the description of the `AndroidManifest.xml` file to include its purpose, structure, and security-relevant elements such as permissions, components, deep links, and backup behavior. Added best practices for securing these elements.
* Included an example `AndroidManifest.xml` file to illustrate key attributes and configurations, such as permissions, backup settings, and exported components.
* Highlighted the importance of analyzing the merged manifest output to identify additional permissions or settings introduced by dependencies.

### MASTG-TECH-0117:
* Added detailed instructions for using `jadx`, `apktool`, and `aapt2` to extract and decode the `AndroidManifest.xml` file from an APK, including tool-specific behaviors and output formats.
* Clarified the handling of the `<uses-sdk>` element by `apktool` and how to modify SDK values in the `apktool.yml` file for rebuilding.
