### PR TITLE
Refactor some iOS techniques to properly link to TOOLs

### DIFF
--- a/techniques/ios/MASTG-TECH-0058.md
+++ b/techniques/ios/MASTG-TECH-0058.md
@@ -5,7 +5,13 @@ platform: ios
 
 Once you have collected the package name of the application you want to target, you'll want to start gathering information about it. First, retrieve the @MASTG-APP-0028 IPA as explained in @MASTG-TECH-0054.
 
-You can unzip the IPA using the standard `unzip` or any other ZIP utility. Inside you'll find a `Payload` folder containing the so-called Application Bundle (.app). The following is an example in the following output, note that it was truncated for better readability and overview:
+You can unzip the IPA using the standard `unzip` or any other ZIP utility.
+
+```bash
+unzip iGoat-Swift.ipa
+```
+
+Inside you'll find a `Payload` folder containing the so-called Application Bundle (.app). The following is an example in the following output, note that it was truncated for better readability and overview:
 
 ```bash
 $ ls -1 Payload/iGoat-Swift.app

--- a/techniques/ios/MASTG-TECH-0111.md
+++ b/techniques/ios/MASTG-TECH-0111.md
@@ -3,18 +3,11 @@ title: Extracting Entitlements from MachO Binaries
 platform: ios
 ---
 
-To extract the entitlements from a MachO binary, the following tools can be used:
+Several tools can be used to extract entitlements from MachO binaries on iOS. This is useful for security assessments, as entitlements can reveal permissions and capabilities granted to an app.
 
-- @MASTG-TOOL-0129
-- @MASTG-TOOL-0111
-- @MASTG-TOOL-0105
-- @MASTG-TOOL-0114
+## Using @MASTG-TOOL-0129
 
-The following examples use these tools on the main binary of @MASTG-APP-0028, which contains two architectures.
-
-## rabin2
-
-The entitlements can be extracted using `rabin2 -OC <binary>`.
+Use rabin2 to extract entitlements from MachO binaries using `rabin2 -OC <binary>`:
 
 ```bash
 rabin2 -OC MASTestApp
@@ -35,9 +28,9 @@ rabin2 -OC MASTestApp
 </plist>
 ```
 
-## ldid
+## Using @MASTG-TOOL-0111
 
-The entitlements can be extracted using `ldid -e <binary>`. The `-A` flag is added to specify the desired architecture (16777228:0, which is CPU_TYPE_ARM64:CPU_SUBTYPE_ARM64_ALL):
+Use ldid to extract entitlements from MachO binaries. The `-e` flag is used to specify that entitlements should be extracted, and the `-A` flag is added to specify the desired architecture (`16777228:0`, which is `CPU_TYPE_ARM64:CPU_SUBTYPE_ARM64_ALL`):
 
 ```bash
 ldid -e -A16777228:0 iGoat-Swift.app/iGoat-Swift
@@ -60,12 +53,12 @@ ldid -e -A16777228:0 iGoat-Swift.app/iGoat-Swift
 </plist>
 ```
 
-## ipsw
+## Using @MASTG-TOOL-0105
 
-The entitlements can be extracted using `ipsw macho info -e <binary>`. The `-a` flag is added to specify the desired architecture:
+Use ipsw to extract entitlements from MachO binaries using the `ipsw macho info -e` command:
 
 ```bash
-ipsw macho info -e iGoat-Swift.app/iGoat-Swift -a arm64
+ipsw macho info -e iGoat-Swift.app/iGoat-Swift
 ```
 
 ```xml
@@ -87,9 +80,9 @@ ipsw macho info -e iGoat-Swift.app/iGoat-Swift -a arm64
 </plist>
 ```
 
-## codesign
+## Using @MASTG-TOOL-0114
 
-The entitlements can be extracted using `codesign -d --entitlements - <binary>`. Make sure to include the `-` as the argument for the `--entitlements` flag:
+Use `codesign` to extract entitlements from a MachO binary using `codesign -d --entitlements - <binary>`. Make sure to include the `-` as the argument for the `--entitlements` flag:
 
 ```bash
 codesign -d --entitlements - iGoat-Swift.app/iGoat-Swift


### PR DESCRIPTION
This pull request updates documentation for iOS security techniques, focusing on improving clarity and usability. The changes include enhanced instructions for unzipping IPA files and reorganizing sections on extracting entitlements from MachO binaries, with detailed examples for various tools.

### Updates to IPA extraction instructions:

* [`techniques/ios/MASTG-TECH-0058.md`](diffhunk://#diff-0ca4b4fbed6358e42051129ab26e1e992bcba801124fcb05263f5b70dd794f46L8-R14): Added a specific command example for unzipping IPA files (`unzip iGoat-Swift.ipa`) to make the instructions more actionable.

### Improvements to entitlement extraction documentation:

* `techniques/ios/MASTG-TECH-0111.md`: Reorganized the entitlement extraction tech by grouping tools into subsections and providing clearer descriptions of their usage.