### PR TITLE
Fix image copy

### DIFF
--- a/src/scripts/structure_mastg.sh
+++ b/src/scripts/structure_mastg.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 mkdir -p docs/MASTG
 mkdir -p docs/MASWE
+mkdir -p docs/assets/Images
 
 directories=("tests" "techniques" "tools" "apps" "demos" "rules" "utils" "best-practices")
 

--- a/src/scripts/structure_mastg.sh
+++ b/src/scripts/structure_mastg.sh
@@ -18,7 +18,7 @@ cp -r weaknesses/** docs/MASWE/ || { echo "Failed to copy weaknesses"; exit 1; }
 cp -r Document/0x0*.md docs/MASTG
 cp -r Document/index.md docs/MASTG
 
-cp -r Document/Images/ docs/assets/Images/
+cp -r Document/Images/* docs/assets/Images/
 
 if [[ "$(uname)" == "Darwin" ]]; then
     SED="gsed"


### PR DESCRIPTION
Without the *, it will copy the Images folder into docs/assets/Images rather than the files. This means images end up in the wrong folder for the website, resulting in 404 images.