### PR TITLE
Update MASTG-DEMO-0027 frida script to lookup flags and result

### DIFF
--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0027/output.txt
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0027/output.txt
@@ -1,27 +1,25 @@
 
-[*] KeyguardManager.isDeviceSecure() called
+
+[*] KeyguardManager.isDeviceSecure() called - RESULT: false
 
 
 Backtrace:
 android.app.KeyguardManager.isDeviceSecure(Native Method)
 org.owasp.mastestapp.MastgTest.isDeviceSecure(MastgTest.kt:24)
 org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:10)
-org.owasp.mastestapp.MainActivityKt$MyScreenContent$1$1$1.invoke(MainActivity.kt:93)
-org.owasp.mastestapp.MainActivityKt$MyScreenContent$1$1$1.invoke(MainActivity.kt:91)
-androidx.compose.foundation.ClickablePointerInputNode$pointerInput$3.invoke-k-4lQ0M(Clickable.kt:987)
-androidx.compose.foundation.ClickablePointerInputNode$pointerInput$3.invoke(Clickable.kt:981)
-androidx.compose.foundation.gestures.TapGestureDetectorKt$detectTapAndPress$2$1.invokeSuspend(TapGestureDetector.kt:255)
-Result: false
+org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$9$lambda$8(MainActivity.kt:53)
+org.owasp.mastestapp.MainActivityKt.$r8$lambda$PhzGLzmkS_ibruOfiTT32AhzWl4(Unknown Source:0)
+org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
+java.lang.Thread.run(Thread.java:1012)
 
-[*] BiometricManager.canAuthenticate(15) called with BIOMETRIC_ERROR_NONE_ENROLLED - No biometrics enrolled.
 
+[*] BiometricManager.canAuthenticate called with: BIOMETRIC_STRONG (15) - RESULT: BIOMETRIC_ERROR_NONE_ENROLLED (11)
 
 Backtrace:
 android.hardware.biometrics.BiometricManager.canAuthenticate(Native Method)
 org.owasp.mastestapp.MastgTest.checkStrongBiometricStatus(MastgTest.kt:38)
 org.owasp.mastestapp.MastgTest.mastgTest(MastgTest.kt:11)
-org.owasp.mastestapp.MainActivityKt$MyScreenContent$1$1$1.invoke(MainActivity.kt:93)
-org.owasp.mastestapp.MainActivityKt$MyScreenContent$1$1$1.invoke(MainActivity.kt:91)
-androidx.compose.foundation.ClickablePointerInputNode$pointerInput$3.invoke-k-4lQ0M(Clickable.kt:987)
-androidx.compose.foundation.ClickablePointerInputNode$pointerInput$3.invoke(Clickable.kt:981)
-androidx.compose.foundation.gestures.TapGestureDetectorKt$detectTapAndPress$2$1.invokeSuspend(TapGestureDetector.kt:255)
+org.owasp.mastestapp.MainActivityKt.MainScreen$lambda$9$lambda$8(MainActivity.kt:53)
+org.owasp.mastestapp.MainActivityKt.$r8$lambda$PhzGLzmkS_ibruOfiTT32AhzWl4(Unknown Source:0)
+org.owasp.mastestapp.MainActivityKt$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
+java.lang.Thread.run(Thread.java:1012)

--- a/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0027/script.js
+++ b/demos/android/MASVS-RESILIENCE/MASTG-DEMO-0027/script.js
@@ -47,21 +47,21 @@ Java.perform(() => {
     [BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED.value]: "BIOMETRIC_ERROR_NONE_ENROLLED"
   };
 
-  originalCanAuth.implementation = function (flags) {
-    // Build readable flags string
+  originalCanAuth.implementation = function (authenticators) {
+    // Build readable authenticators string
     const names = Object.keys(flagNames)
       .map(key => parseInt(key, 10))
-      .filter(key => (flags & key) === key)
+      .filter(key => (authenticators & key) === key)
       .map(key => flagNames[key]);
     const readable = names.length ? names.join(" | ") : "NONE";
 
     // Call original
-    const res = originalCanAuth.call(this, flags);
+    const res = originalCanAuth.call(this, authenticators);
 
     // Lookup result message
     const msg = resultMessages[res] || `Unknown biometric status: ${res}`;
 
-    console.log(`\n\n[*] BiometricManager.canAuthenticate called with: ${readable} (${flags}) - RESULT: ${msg} (${res})`);
+    console.log(`\n\n[*] BiometricManager.canAuthenticate called with: ${readable} (${authenticators}) - RESULT: ${msg} (${res})`);
 
     printBacktrace();
 


### PR DESCRIPTION
This PR enhances the existing Frida demo script to surface return values and flag names in the logs and updates the sample output accordingly.

- The `KeyguardManager.isDeviceSecure` hook now logs the method’s boolean result.
- The `BiometricManager.canAuthenticate` hook is refactored to map integer flags and result codes to human-readable names.
- The example output is updated to show the new “flags” and “RESULT” formats and trims unrelated stack frames.
