### PR TITLE
Update MASTG-TEST-0210 with Blowfish and third-party or custom implementations

### DIFF
--- a/tests-beta/ios/MASVS-CRYPTO/MASTG-TEST-0210.md
+++ b/tests-beta/ios/MASVS-CRYPTO/MASTG-TEST-0210.md
@@ -11,17 +11,17 @@ profiles: [L1, L2]
 
 To test for the use of weak encryption algorithms in iOS apps, we need to focus on methods from cryptographic frameworks and libraries that are used to perform encryption and decryption operations.
 
-- **CommonCrypto**: The [`CCCrypt`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/CCCrypt.3cc.html) function is used for **symmetric algorithms** and specifies the algorithm in its second parameter `alg`. This includes:
+- **CommonCrypto**: The [`CCCrypt`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/CCCrypt.3cc.html) function is used for **symmetric algorithms** and specifies the algorithm in its second parameter `alg` which can be one of the following [`CCAlgorithm`](https://github.com/Apple-FOSS-Mirror/CommonCrypto/blob/v60026/CommonCrypto/CommonCryptor.h#L149-L158) constants:
     - `kCCAlgorithmAES128`
     - `kCCAlgorithmDES`
     - `kCCAlgorithm3DES`
     - `kCCAlgorithmCAST`
     - `kCCAlgorithmRC4`
     - `kCCAlgorithmRC2`
+    - `kCCAlgorithmBlowfish`
 
-- **CryptoKit**: This library does not support weak encryption algorithms. It supports the following **symmetric algorithms**:
-    - `AES.GCM`
-    - `ChaChaPoly`
+- **CryptoKit**: This library does not support weak encryption algorithms. It only supports secure **symmetric algorithms** including `AES.GCM` and `ChaChaPoly`.
+- **Third-party libraries**: Applications may include cryptographic functions through third-party libraries such as OpenSSL, BoringSSL, Libsodium, or even custom cryptographic implementations. These may support or expose weak encryption algorithms like DES, 3DES, RC2, RC4, or Blowfish.
 
 Note: the **Security** framework only supports asymmetric algorithms and is therefore out of scope for this test (see [note about symmetric keys](https://developer.apple.com/documentation/security/certificate_key_and_trust_services/keys/generating_new_cryptographic_keys#2863931)).
 
@@ -41,6 +41,9 @@ The test case fails if you can find the use of weak encryption algorithms within
 - 3DES
 - RC2
 - RC4
+- Blowfish
+
+This applies to Apple-provided APIs (e.g., CommonCrypto), third-party libraries (e.g., OpenSSL, Libsodium) and any custom implementations of cryptographic routines that replicate insecure algorithms (e.g., DES in C code) or use insecure configurations (e.g., ECB mode, short key sizes) 
 
 **Stay up-to-date**: This is a non-exhaustive list of weak algorithms. Make sure to check the latest standards and recommendations from organizations such as the National Institute of Standards and Technology (NIST), the German Federal Office for Information Security (BSI) or any other relevant authority in your region.
 


### PR DESCRIPTION
This pull request updates `MASTG-TEST-0210`.

## Overview

* **Added algorithm examples for `CommonCrypto`**: Added `kCCAlgorithmBlowfish` to the list of supported algorithms for the `CCCrypt` function. Clarified that the `alg` parameter uses constants from the `CCAlgorithm` enumeration.
* **Third-party library considerations**: Documented the potential use of weak encryption algorithms in third-party libraries (e.g., OpenSSL, BoringSSL, Libsodium) and custom implementations.

### Evaluation

* **Additional weak algorithm**: Included `Blowfish` in the list of weak encryption algorithms that cause the test case to fail.
* **Broader applicability**: Extended the scope of the test case to include weak algorithms used in Apple APIs, third-party libraries, and custom cryptographic routines, with examples of insecure configurations (e.g., ECB mode, short key sizes).